### PR TITLE
Servers content audit

### DIFF
--- a/content/cloud-dns/create-a-dkim-txt-record.md
+++ b/content/cloud-dns/create-a-dkim-txt-record.md
@@ -6,8 +6,8 @@ created_date: '2012-07-24'
 created_by: Rackspace Support
 last_modified_date: '2016-01-15'
 last_modified_by: Stephanie Fillmon
-product: Cloud Servers
-product_url: cloud-servers
+product: Cloud DNS
+product_url: cloud-dns
 ---
 
 DomainKeys Identified Mail (DKIM) helps you protect your company from
@@ -16,7 +16,7 @@ validating a domain name identity that is associated with a message
 through cryptographic authentication.
 
 For a complete description of DKIM, see a recommended list of DKIM sites
-under [External Links](#ExternalLinks).
+in the "External resources" section below.
 
 The process of setting up DKIM involves several tasks:
 
@@ -30,8 +30,7 @@ The process of setting up DKIM involves several tasks:
 This article describes how to create the selector and publish the DKIM
 TXT record.
 
-Create a DKIM TXT record
-------------------------
+### Create a DKIM TXT record
 
 **Note:** Before you perform this procedure, choose a text string to use
 as your selector and generate a public/private key pair. To publish the
@@ -39,8 +38,7 @@ DKIM selector and private key
 
 **To publish the DKIM selector and private key**:
 
-![Add DNS
-Record](http://c691244.r44.cf2.rackcdn.com/Add%20DNS%20Record.png)
+![Add DNS Record](http://c691244.r44.cf2.rackcdn.com/Add%20DNS%20Record.png)
 
 1.  Log in to the [Cloud Control Panel](https://mycloud.rackspace.com/).
 2.  In the top navigation bar, select **Networking &gt; Cloud DNS**.
@@ -54,7 +52,9 @@ Record](http://c691244.r44.cf2.rackcdn.com/Add%20DNS%20Record.png)
     example, if you use default as the text string and myexampledomain
     is your domain name, the selector would look as follows:
 
+   ```
         default._domainkey.myexampledomain.com
+   ```
 
     You need to enter only the text string and **`._domainkey`** in the
     **Hostname** text box.
@@ -67,8 +67,7 @@ Record](http://c691244.r44.cf2.rackcdn.com/Add%20DNS%20Record.png)
     When you are finished, the TXT record will look similar to the
     following example:
 
-    ![DKIM DNS TXT
-    Record](http://c691244.r44.cf2.rackcdn.com/Add%20DKIM%20DNS%20TXT%20Record.png)
+    ![DKIM DNS TXT Record](http://c691244.r44.cf2.rackcdn.com/Add%20DKIM%20DNS%20TXT%20Record.png)
 
 7.  Click **Add Record**.
 
@@ -77,19 +76,14 @@ The DNS TXT record is added to your domain.
 For instructions on attaching the token to your outgoing email, go to
 [DKIMcore.org](http://dkimcore.org/)
 
-### Related
+### Related articles
 
-[Setting up SPF DNS TXT
-Records](/how-to/create-an-spf-txt-record)
+[Setting up SPF DNS TXT Records](/how-to/create-an-spf-txt-record)
 
-[Learn More about
-DNS](/how-to/learn-more-about-dns)
+[Learn More about DNS](/how-to/learn-more-about-dns)
 
-### External Links
+### External resources
 
 [Dkim.org](http://www.dkim.org)
 
 [DKIMcore.org](http://dkimcore.org/specification.html)
-
-
-

--- a/content/cloud-dns/create-a-reverse-dns-record-0.md
+++ b/content/cloud-dns/create-a-reverse-dns-record-0.md
@@ -6,18 +6,14 @@ created_date: '2011-04-04'
 created_by: Rackspace Support
 last_modified_date: '2015-12-29'
 last_modified_by: Stephanie Fillmon
-product: Cloud Servers
-product_url: cloud-servers
+product: Cloud DNS
+product_url: cloud-dns
 ---
 
 In this article we discuss how to add a reverse DNS record (also known
 as an RDNS record and a PTR record) to map your server's IP address to a
 domain name (for example, 1.2.3.4. to example.com). We use the Cloud
 Control Panel.
-
--   [Why reverse DNS lookups?](#dns)
--   [How does it work?](#work)
--   [How do I set it up?](#setup)
 
 ### Why reverse DNS lookups?
 
@@ -27,9 +23,9 @@ originates from an "unauthenticated" server.
 
 This means that after the sending IP address is checked, if the reverse
 DNS does not match the sending domain, then it is classed as
-&ldquo;unauthenticated&rdquo;.
+"unauthenticated".
 
-We put &rdquo;unauthenticated&rdquo; in quotes because having a Reverse DNS record
+We put "unauthenticated" in quotes because having a Reverse DNS record
 attached to your domain does not automatically guarantee acceptance of
 email originating from your domain by the recipient's email server. It's
 just that non-matching or generic reverse DNS lookup settings are often
@@ -56,18 +52,16 @@ server on their Cloud Server.
 You can easily set up reverse DNS through the control panel. Just
 perform these steps:
 
-1.  Log in to your Rackspace account with the [Cloud Control
-    Panel](http://mycloud.rackspace.com).
+1.  Log in to your Rackspace account with the [Cloud Control Panel](http://mycloud.rackspace.com).
 2.  On the Servers tab, click the link for your Cloud Server from your
     Servers List.
 3.  On the **Server Details** screen, click **Add Record** next to the
     Reverse DNS.
 
-    ![Add record link for Reverse DNS under Server
-    Details](https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/reverse%20DNS_add.png)
+    ![Add record link for Reverse DNS under Server Details](https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/reverse%20DNS_add.png)
 
 4.  In the Add Record pop-up window:
-    -   Enter you domain name (for example &ldquo;mail.example.com&rdquo;) in the
+    -   Enter your domain name (for example **mail.example.com**) in the
         **Hostname** field.
     -   Set the Time to Live (TTL) for the record.
     -   Click **Save Record**.
@@ -77,6 +71,3 @@ perform these steps:
     reverse DNS you just added.
 
     <img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/Article64-3.jpeg" width="713" height="173" />
-
-
-

--- a/content/cloud-dns/create-an-spf-txt-record.md
+++ b/content/cloud-dns/create-an-spf-txt-record.md
@@ -6,8 +6,8 @@ created_date: '2012-07-24'
 created_by: Rackspace Support
 last_modified_date: '2016-01-15'
 last_modified_by: Stephanie Fillmon
-product: Cloud Servers
-product_url: cloud-servers
+product: Cloud DNS
+product_url: cloud-dns
 ---
 
 Email spammers commonly forge the sender address in an email; they send
@@ -15,17 +15,13 @@ email from their mail servers but with your domain as the sending email.
 The Sender Policy Framework (SPF) attempts to control forged email by
 giving domain owners a way to specify which email sources are legitimate
 for their domain and which ones aren't. For detailed information about
-SPF, see [Sender Policy Framework Project
-Overview](http://www.openspf.org/).
+SPF, see [Sender Policy Framework Project Overview](http://www.openspf.org/).
 
 You can add an SPF record to your DNS zone as a TXT record. The SPF
 record is associated with your domain and specifies which mail server or
 servers the domain uses to send email.
 
-
-
-<span class="mw-headline">Considerations for setting the SPF</span>
--------------------------------------------------------------------
+### Considerations for setting the SPF
 
 To correctly set the SPF for your domain, answer the following
 questions:
@@ -39,9 +35,7 @@ questions:
     a "soft fail," meaning that the email will be subjected to
     further scrutiny.
 
-
-
-### <span class="mw-headline">Example of how to create an SPF rule</span>
+### Example of how to create an SPF rule
 
 Suppose you have the following considerations for your email on a
 specific domain:
@@ -52,51 +46,40 @@ specific domain:
 
 You would create the following rule and add it to a TXT record:
 
-    v=spf1 mx include:_spf.google.com -all
+```
+v=spf1 mx include:_spf.google.com -all
+```
 
 Each part of the record is defined as follows:
 
 -   **v=spf1** sets the SPF version being used.
 
-<!-- -->
-
 -   **mx** allows the domain's MX details to send email.
-
-<!-- -->
 
 -   **include:\_spf.google.com** includes Google mail servers as
     authorized servers.
-
-<!-- -->
 
 -   **-all** indicates that servers that are not listed previously are
     *not* authorized to send email. If an unauthorized server does send
     email, action is taken according to the receiving mail server's own
     policy (for example, delete the email or mark it as spam).
 
-### <span class="mw-headline">About the all setting</span>
+### About the all setting
 
 The **all** setting is an important aspect of the record and has the
 following basic markers:
 
--   -**all** &ndash; Any server not previously listed is not authorized to
+-   -**all** - Any server not previously listed is not authorized to
     send email, no questions asked.
 
-<!-- -->
-
--   **\~all** &ndash; If mail is received from a server that is not previously
+-   **~all** - If mail is received from a server that is not previously
     listed, it is marked as a soft fail, which allows the email to be
     scrutinized further.
 
-<!-- -->
-
--   **+all **&ndash; Allow any server to send email from your domain.
+-   **+all** - Allow any server to send email from your domain.
     Naturally, you should never use this option.
 
-
-
-<span class="mw-headline">Adding an SPF TXT record</span>
----------------------------------------------------------
+### Adding an SPF TXT record
 
 To add an SPF TXT record by using the Cloud Control Panel, follow these
 steps:
@@ -107,18 +90,13 @@ steps:
     to modify, and select **Add DNS Record**.
 4.  Select **TXT Record** for the record type.
 5.  Enter the rule in the **Text** area. For example, enter
-    `v=spf1 mx &ndash;all` to indicate that all email is sent from this server
+    `v=spf1 mx -all` to indicate that all email is sent from this server
     and no other mail servers are authorized.
 6.  Specify the Time To Live (TTL).
 7.  Click **Add Record**.
 
-![DNS SPF
-Record](http://c691244.r44.cf2.rackcdn.com/SPF%20Record%20DNS.png)
+![DNS SPF Record](http://c691244.r44.cf2.rackcdn.com/SPF%20Record%20DNS.png)
 
+### Related articles
 
-
-**Related information**
-
-[Creating a DKIM TXT
-Record](/how-to/create-a-dkim-txt-record)
-
+[Creating a DKIM TXT Record](/how-to/create-a-dkim-txt-record)

--- a/content/cloud-networks/create-an-isolated-cloud-network-and-attach-it-to-a-server.md
+++ b/content/cloud-networks/create-an-isolated-cloud-network-and-attach-it-to-a-server.md
@@ -6,16 +6,15 @@ created_date: '2012-09-17'
 created_by: Susan Million
 last_modified_date: '2016-01-10'
 last_modified_by: Renee Rendon
-product: Cloud Servers
-product_url: cloud-servers
+product: Cloud Networks
+product_url: cloud-networks
 ---
 
 With Cloud Networks you can create a virtual layer 2 network that you
 can attach to a new cloud server. This feature lets you keep your Cloud
 Server separate from the Rackspace network, the Internet, or both.
 
-Cloud Network limitations
--------------------------
+### Cloud Network limitations
 
 -   The Cloud Network must exist in the same region as the server.
 
@@ -24,8 +23,7 @@ Cloud Network limitations
 
 -   A network cannot be renamed after it is created.
 
-Attach an isolated network to a cloud server
---------------------------------------------
+### Attach an isolated network to a cloud server
 
 1.  In the [Cloud Control Panel](https://mycloud.rackspace.com).
     The Cloud Servers page is displayed by default.
@@ -67,19 +65,12 @@ Network named My Private Network:
 
 <img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/Cloud%20Networks%20List.png" alt="Cloud Networks List" width="743" height="224" />
 
-More information about Cloud Networks
--------------------------------------
+### More information about Cloud Networks
 
-[Attach an Isolated Network to an Existing Cloud
-Server](/how-to/attach-a-cloud-network-to-an-existing-cloud-server "Attach an Isolated Network to an Existing Cloud Server")
+[Attach an Isolated Network to an Existing Cloud Server](/how-to/attach-a-cloud-network-to-an-existing-cloud-server)
 
-[Removing Networks from a Cloud
-Server](/how-to/removing-networks-from-a-cloud-server "Removing Networks from a Cloud Server")
+[Removing Networks from a Cloud Server](/how-to/removing-networks-from-a-cloud-server)
 
-[<span class="s1">CIDR
-Notation</span>](/how-to/using-cidr-notation-in-cloud-networks "CIDR Notation")
+[CIDR Notation](/how-to/using-cidr-notation-in-cloud-networks "CIDR Notation")
 
 [Cloud Networks Developer Guide](https://developer.rackspace.com/docs/)
-
-
-

--- a/content/cloud-servers/connecting-to-linux-from-mac-os-x-by-using-terminal.md
+++ b/content/cloud-servers/connecting-to-linux-from-mac-os-x-by-using-terminal.md
@@ -10,23 +10,21 @@ product: Cloud Servers
 product_url: cloud-servers
 ---
 
-If you use Mac OS X, you don&rsquo;t need to install a third-party client like
+If you use Mac OS X, you don't need to install a third-party client like
 PuTTY to connect to your cloud server via Secure Shell (SSH). Terminal
 is a terminal emulation program included with Mac OS X that you can use
 to run SSH.
 
-**Note**: For an OnMetal Server, see [Create OnMetal Cloud
-Servers](/how-to/create-onmetal-cloud-servers) for
+**Note**: For an OnMetal Server, see [Create OnMetal Cloud Servers](/how-to/create-onmetal-cloud-servers) for
 applicable OnMetal steps.
 
-Connect to the server
----------------------
+### Connect to the server
 
 These instructions are for users who are connecting to a new cloud
-server for the first time.  If you&rsquo;re connecting as a non-root user,
+server for the first time. If you're connecting as a non-root user,
 replace *root* in the instructions with your username.
 
-1.  Go to **Applications** &gt; **Utilities**, and open **Terminal**.
+1.  Go to **Applications > Utilities**, and open **Terminal**.
 
     <img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/1-FindTerm_1_0.png" width="550" />
 
@@ -66,8 +64,7 @@ replace *root* in the instructions with your username.
 
         [root@yourservername ~]#
 
-Change the root password
-------------------------
+### Change the root password
 
 After your first login, change the root password.
 
@@ -88,11 +85,8 @@ After your first login, change the root password.
 
 Use the new password with the root user when you connect to your server.
 
-Where to go from here
----------------------
+### Where to go from here
 
-The next article shows you how to use [Rescue
-Mode](/how-to/rescue-mode)
+The next article shows you how to use [Rescue Mode](/how-to/rescue-mode)
 to connect to your cloud server, which is useful when you are performing
 troubleshooting and when your server becomes unresponsive.
-

--- a/content/cloud-servers/connecting-to-linux-from-windows-by-using-putty.md
+++ b/content/cloud-servers/connecting-to-linux-from-windows-by-using-putty.md
@@ -12,42 +12,32 @@ product_url: cloud-servers
 
 ### Previous section
 
-[Getting Started with Cloud
-Servers](/how-to/create-a-cloud-server)
+[Create a Cloud Server](/how-to/create-a-cloud-server)
 
-After you have [created a new cloud
-server](/how-to/create-a-cloud-server)
+After you have created a new cloud server
 with the control panel, your next step is to make a secure remote
-connection from your local computer to your cloud server.  This article
+connection from your local computer to your cloud server. This article
 describes how to use a client called PuTTY to form an Secure Shell (SSH)
 connection from a computer running a Microsoft Windows OS to a Linux
 server.
 
 **Notes**:
 
--   For an OnMetal Server, see the [Create OnMetal Cloud
-    Servers](/how-to/create-onmetal-cloud-servers)
+-   For an OnMetal Server, see the [Create OnMetal Cloud Servers](/how-to/create-onmetal-cloud-servers)
     article for applicable OnMetal steps.
 -   This procedure requires you to install PuTTY or another SSH client
     which you do at your own risk.  PuTTY is not affiliated with
     Rackspace in any way, but their software is simple to use, is freely
     available, and reputable.
--   If you are a Mac OS X user, you can [connect to a Linux server by
-    using
-    Terminal](/how-to/connecting-to-linux-from-mac-os-x-by-using-terminal), a
+-   If you are a Mac OS X user, you can [connect to a Linux server by using Terminal](/how-to/connecting-to-linux-from-mac-os-x-by-using-terminal), a
     console program included with the operating system.
 
+#### Windows versions
 
-
-Windows versions
-----------------
-
-The procedure and examples in this article use  Windows XP, Service Pack
-2.  Different versions of Windows may have slightly different
+The procedure and examples in this article use  Windows XP, Service Pack 2. Different versions of Windows may have slightly different
 interfaces.
 
-Download PuTTY
---------------
+### Download PuTTY
 
 Download PuTTY from the
 [website](http://www.chiark.greenend.org.uk/~sgtatham/putty/ "http://www.chiark.greenend.org.uk/~sgtatham/putty/").
@@ -55,8 +45,7 @@ Be sure to comply with the license requirements.
 
 After you download PuTTY, launch the application.
 
-Configure you connection
-------------------------
+### Configure your connection
 
 In the PuTTY Configuration window, enter the following values and then
 click **Open**:
@@ -70,11 +59,7 @@ click **Open**:
 
 ![](http://c768825.r25.cf2.rackcdn.com/1_Connect.png)
 
-
-
-Accept the key
---------------
-
+### Accept the key
 
 If this is the first time that you have used PuTTY to log in to your
 server with SSH, a warning similar to the following one is displayed:
@@ -88,12 +73,7 @@ is now cached in the registry of your local computer.  You can expect to
 see that warning, however, if you connect to your server from a
 different computer.
 
-
-
-
-
-Enter your username and password
---------------------------------
+### Enter your username and password
 
 After you accept the warning, the terminal prompts you for your username
 and password.
@@ -114,10 +94,10 @@ a shell prompt:
 
 Now you can work on your server with all permissions.
 
-Change your root passwords
+### Change your root passwords
 
 FWe recommend that you change the root password to something personal.
- You can easily do this by using the passwd command.
+ You can easily do this by using the `passwd` command.
 
 1.  From the shell prompt, enter the passwd command.
 2.  Enter the new password that you want to set for your server.  The
@@ -133,6 +113,4 @@ to your server.
 
 ### Next section
 
-[Remote Connection from Mac to a Linux
-Server](/how-to/connecting-to-linux-from-mac-os-x-by-using-terminal)
-
+[Remote Connection from Mac to a Linux Server](/how-to/connecting-to-linux-from-mac-os-x-by-using-terminal)

--- a/content/cloud-servers/create-a-cloud-server.md
+++ b/content/cloud-servers/create-a-cloud-server.md
@@ -13,8 +13,7 @@ product_url: cloud-servers
 Use the following steps to set up a Cloud Server through the Cloud
 Control Panel interface.
 
-1.  Log in to the [Cloud Control
-    Panel](https://mycloud.rackspace.com). The Cloud Servers list opens
+1.  Log in to the [Cloud Control Panel](https://mycloud.rackspace.com). The Cloud Servers list opens
     by default.
 2.  Click the **Create Server** button.
 3.  In the** Identity **section enter a name for your server in
@@ -54,19 +53,15 @@ Control Panel interface.
     -   In the Region field, confirm or select the region in which your
         key will be used
     -   Paste your public key into the Public Key field.
-        **Note:** If you do not have a public key yet, click [How to get
-        a public
-        key](/how-to/connecting-to-a-server-using-ssh-on-linux-or-mac-os)
+
+        **Note:** If you do not have a public key yet, click [How to get a public key](/how-to/connecting-to-a-server-using-ssh-on-linux-or-mac-os)
         and follow the instructions in that article.
-                  For more information on how to generate a public and
-        private key pairs, see
-                  [Manage SSH Keypairs for Cloud Servers
-        with-python-novaclient](/how-to/manage-ssh-key-pairs-for-cloud-servers-with-python-novaclient).
+        For more information on how to generate a public and
+        private key pairs, see [Manage SSH Keypairs for Cloud Servers with-python-novaclient](/how-to/manage-ssh-key-pairs-for-cloud-servers-with-python-novaclient).
     -   Once you have your entered your Key Name, Region, and the Public
         Key, click **Add Public Key**.
 
-
-    ******<img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/Screen%20Shot%202015-01-14%20at%209.30.59%20AM.png" width="655" height="299" />
+  <img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/Screen%20Shot%202015-01-14%20at%209.30.59%20AM.png" width="655" height="299" />
 
 9.  Confirm that your key is listed in the SSH Key list for your new
     server.
@@ -76,16 +71,11 @@ Control Panel interface.
 
 11. Click **Create Server**.
 
-
 Your server is built. After it is done being provisioned, your server
 displays the status **Running** and is now available for remote
 connection. Specific remote connection instructions for your server are
 displayed in the side bar on the right of the Cloud Control Panel.
 
+### Next section
 
-
-**Next section**
-
-[Create an image from a server and restore a server from a saved
-image](/how-to/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image)
-
+[Create an image from a server and restore a server from a saved image](/how-to/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image)

--- a/content/cloud-servers/create-a-csr-in-the-cloud-control-panel.md
+++ b/content/cloud-servers/create-a-csr-in-the-cloud-control-panel.md
@@ -14,16 +14,9 @@ Rackspace  provides a tool for generating a certificate signing request, or CSR.
 
 When you are done with the generator, you can return to the Cloud Control Panel by clicking any of the terms in the top navigation or by going to [mycloud.rackspace.com](https://mycloud.rackspace.com).
 
-**Tip**: You can also generate a CSR and private key on your Linux Cloud Server using OpenSSL.  For more information, see [Generate a CSR with OpenSSL](/how-to/generate-a-csr-with-openssl).
-<a name="top"></a>
+**Note**: You can also generate a CSR and private key on your Linux Cloud Server using OpenSSL.  For more information, see [Generate a CSR with OpenSSL](/how-to/generate-a-csr-with-openssl).
 
-*   [Access the CSR Generator](#access)
-*   [Generate the CSR](#create)
-*   [View CSR details](#view)
-*   [Submit your CSR to the Certificate Authority](#submit)
-*   [Install the private key](#install)
-
-## <a name="access"></a>Access the CSR Generator
+### Access the CSR Generator
 
 Click the following link to access the [CSR Generator](https://csrgenerator.rackspace.com).
 
@@ -31,14 +24,11 @@ After you log in, the generator lists your existing CSRs (if any), organized by 
 
 <img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/CSR_gen_1.png" width="650" alt="Main page of CSR Generator, showing list of certificate requests for domains."  />
 
-[< top >](#top)
-
-## <a name="create"></a>Generate a CSR
+### Generate a CSR
 
 Step 1. Click the **Create CSR** button.
 
 Step 2. Enter the following information, which will be associated with the CSR:
-
 
 | Field | Explanation | Example |
 | --- | --- | --- |
@@ -53,20 +43,17 @@ Step 2. Enter the following information, which will be associated with the CSR:
 | Private Key Bit Length | Key sizes smaller than 2048 are considered insecure and may not be accepted by a Certificate Authority. | 1024,2048,4096 |
 | Hashing Algorithm | Both algorithms are currently trusted in mainstream browsers and offer industry recommended security.  SHA-512 requires additional CPU processing. | SHA-256, SHA-512 |
 
-**NOTE:** You cannot use the following characters in the **Organization Name** or **Organizational Unit** fields:
+**Note:** You cannot use the following characters in the **Organization Name** or **Organizational Unit** fields:
 
     < > ~ ! @ # $ % ^ * / \ ( ) ? . , &
 
 <img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/csr_gen_form.png" width="650" alt="Create CSR form"  />
 
-
 Step 3. After you have entered all the required information, click **Create CSR**.
 
 It can take between 5 and 60 seconds for the CSR to be generated.  You might need to refresh the page that displays your CSRs before the new CSR is listed.
 
-[< top >](#top)
-
-## <a name="view"></a>View CSR details
+### View CSR details
 
 When CSR has been generated, you can click its UUID (unique identifier) in the CSR list to view its details screen.
 
@@ -74,18 +61,12 @@ When CSR has been generated, you can click its UUID (unique identifier) in the C
 
 This screen displays the information that you provided, the text of the CSR, and its associated private key.
 
-[< top >](#top)
-
-## <a name="submit"></a>Submit the CSR to the CA
+### Submit the CSR to the CA
 
 The text in the **Certificate Request** field is the CSR. It contains encoded details of the CSR and your public key.
 
 To request your SSL certificate copy the** Certificate Request** text and submit it to your CA. Include all the text, including the **BEGIN** and **END**  lines at the beginning and end of the text block.
 
-[< top >](#top)
-
-## <a name="install"></a>Install the private key
+### Install the private key
 
 Copy the private key to the server that will host the certificate.  See your application documentation to determine where to install the private key and certificate on your server.
-
-[< top >](#top)

--- a/content/cloud-servers/create-an-image-of-a-general-purpose-v1-cloud-server.md
+++ b/content/cloud-servers/create-an-image-of-a-general-purpose-v1-cloud-server.md
@@ -13,16 +13,14 @@ product_url: cloud-servers
 This article walks you through creating an on-demand image of a General
 Purpose v1 Cloud Server. You can also schedule a daily image for your
 Cloud Servers using the Cloud Control Panel. If you are interested in
-creating an image of a virtual cloud server, see [Creating an Image of
-Your Performance Flavor Server with the Control
-Panel](/how-to/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image).
+creating an image of a virtual cloud server, see [Creating an image of your Performance Flavor Server with the Control Panel](/how-to/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image).
 
-**NOTE**: This is an optional service that incurs storage and bandwidth
+**Note**: This is an optional service that incurs storage and bandwidth
 charges on Cloud Files, however the convenience of easily restoring a
 server from a saved image is extremely valuable. We strongly recommend
 scheduling the creation of server images.
 
-### **Create an Image**
+### Create an Image
 
 1.  Log into the Cloud Control Panel.
 
@@ -36,8 +34,7 @@ scheduling the creation of server images.
 4.  (Optional) Enter a new image name in the pop-up for the image. If
     you don't enter a name, the server name is used as the image name.
 
-    ![Create
-    Image](http://c691244.r44.cf2.rackcdn.com/On-Demand%20Image.png)
+    ![Create Image](http://c691244.r44.cf2.rackcdn.com/On-Demand%20Image.png)
 
 5.  Click **Create Image**.
 
@@ -52,11 +49,7 @@ the **Actions** menu from the details page of a specific server:
 
 <img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/ImageMenu2.png" width="546" height="309" />
 
-
--
-
-Locate a Saved Image
---------------------
+### Locate a Saved Image
 
 To locate a previously saved image, do the following:
 
@@ -66,6 +59,3 @@ To locate a previously saved image, do the following:
     section, **Rackspace** and **Saved**.
 
 3.  Click the **Saved** tab. All your saved images appear on this tab.
-
-
-

--- a/content/cloud-servers/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image.md
+++ b/content/cloud-servers/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image.md
@@ -10,12 +10,12 @@ product: Cloud Servers
 product_url: cloud-servers
 ---
 
-## Previous section
+### Previous section
 [Create a Cloud Server](/how-to/create-a-cloud-server)
 
 This article guides you through the process of creating an image of a cloud server (also known as cloning a server) and restoring a server from a saved image in the Cloud Control Panel. For information about using the Cloud Servers API to create an image from a server, see the [Create Image section in the Cloud Servers Developer Guide](http://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#create-image-of-specified-server).
 
-### Notes
+#### Notes
 
 - An image can be restored only to a server that has enough system disk capacity to accommodate the data in the image.
 
@@ -23,7 +23,7 @@ This article guides you through the process of creating an image of a cloud serv
 
 - Images do not include attached data disks or Cloud Block Storage volumes, only a local system disk. Data disks must be backed up using a Cloud Block Storage volume, Cloud Backup, or another backup solution. For more information about Cloud Backup, see [Getting Started with Rackspace Cloud Backup](/how-to/cloud-backup).
 
-## Create an image backup
+### Create an image backup
 
 **Note:** The process of building a server from a previous backup image can be a time-consuming process depending on the size of the server.
 
@@ -41,7 +41,7 @@ This article guides you through the process of creating an image of a cloud serv
 
 After the image is saved, it appears in the Images section of the Server Information page.
 
-## Restore a server from a saved image
+### Restore a server from a saved image
 
 1. In the top navigation bar of the Cloud Control Panel, click **Servers > Saved Images**.
 
@@ -71,5 +71,5 @@ While your server goes through the build process, a Building notification is dis
 
 After the server is created, its status is displayed as Active. You can then log in to it by using Remote Desktop Protocol (RDP) for Windows or SSH for Linux, depending on your server's operating system.
 
-## Next section
+### Next section
 [Snapshot Limitations](/how-to/rackspace-cloud-essentials-cloud-server-image-limitations)

--- a/content/cloud-servers/create-an-inbound-port-allow-rule-for-windows-firewall-2008.md
+++ b/content/cloud-servers/create-an-inbound-port-allow-rule-for-windows-firewall-2008.md
@@ -12,84 +12,67 @@ product_url: cloud-servers
 
 ### Previous section
 
-[Getting Started with Cloud
-Servers](https://www.rackspace.com/knowledge_center/getting-started/cloud-servers)
+[Create a Cloud Server](/how-to/create-a-cloud-server)
 
+### Creating an Inbound Port Allow Rule
 
+1. Launch Windows Firewall with Advanced Security by clicking on **Start > Administrative Tools > Windows Firewall with Advanced Security**.
 
+  ![firewalllaunch.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/firewalllaunch.png)
 
-
-<span class="mw-headline">Creating an Inbound Port Allow Rule </span>
----------------------------------------------------------------------
-
-1\. Launch Windows Firewall with Advanced Security by clicking on Start
-&gt; Administrative Tools &gt; Windows Firewall with Advanced Security.
-
-![firewalllaunch.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/firewalllaunch.png)
-
-
-2. Select Inbound Rules in the left pane and click New Rule under
+2. Select **Inbound Rules** in the left pane and click **New Rule** under
 Inbound Rules in the Actions Pane
 
-![inboundrule.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundrule.png)
+  ![inboundrule.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundrule.png)
 
+3. The New Inbound Rule Wizard will launch. Select **Port** and click **Next**.
 
-3. The New Inbound Rule Wizard will launch. Select Port and click Next.
-
-![inboundport1.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundport1.png)
-
+  ![inboundport1.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundport1.png)
 
 4. This screen is to determine if this rule applies to TCP or UDP
 protocol and all ports or specific port(s). Select either TCP or UDP and
 then either select all ports or select "Specific local ports:" and fill
-in the port(s) separating them with a comma if necessary. Click next to
+in the port(s) separating them with a comma if necessary. Click **Next** to
 continue.
 
-![inboundport2.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundport2.png)
-
+  ![inboundport2.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundport2.png)
 
 5. Since this is for an allow rule you will need to select weather to
 allow this traffic for all connections (secure and insecure) or only if
 the connection is secure. If you require the connection to be secure you
 can also specify if it also requires Encryption or if it overrides block
-rules. Click Next to continue.
+rules. Click **Next** to continue.
 
-![inboundport3.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundport3.png)
+  ![inboundport3.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundport3.png)
 
-6\. On this screen you can select which profiles the rule applies to.
+6. On this screen you can select which profiles the rule applies to.
 Domain applies when the inbound connection is coming from a computer
 within the domain. Private applies when the inbound connection is coming
 from a source that has selected Private for it's profile. Public applies
 to all connections coming from a source whose profile is set to Public.
-You can select one, two or all three. Click Next to continue.
+You can select one, two or all three. Click **Next** to continue.
 
-![inboundrulewiz6.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundrulewiz6.png)
-
+  ![inboundrulewiz6.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundrulewiz6.png)
 
 7. This is the screen were you will give the rule a name and any
-description you would like to specify. Click Finish to create the rule
+description you would like to specify. Click **Finish** to create the rule
 and go back to the main screen.
 
-![inboundrulewiz7.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundrulewiz7.png)
-
-
+  ![inboundrulewiz7.png](http://c0625232.cdn.cloudfiles.rackspacecloud.com/inboundrulewiz7.png)
 
 That covers the basics of what you need to know for connecting to, and
 setting up security for both Linux and Windows Cloud Servers.  If you
-have made it through this entire guide, you know that this is a somehwat
+have made it through this entire guide, you know that this is a somewhat
 complicated process with, a lot of potentially new information to
-digest.  The good news is that, if you use your server's backup
+digest. The good news is that, if you use your server's backup
 capabilities wisely, you should only have to go through these steps
-once.  In the next guide we show you how to save an image after of your
-Cloud Server.  This is extremely useful for when you build your next
+once.  
+
+In the next article we show you how to save an image after of your
+Cloud Server. This is extremely useful for when you build your next
 server, you can use the saved image with the security already
 configured.
 
-
-
 ### Next steps
 
-Return to the Cloud Servers Getting Started Guide and chose the
-applicable option for [uploading your
-content](https://admin.rackspace.com/knowledge_center/article/introducing-the-rackspace-cloud-control-panel).
-
+[Create an image of a server and restore a server form a saved image](/how-to/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image)

--- a/content/cloud-servers/create-onmetal-cloud-servers.md
+++ b/content/cloud-servers/create-onmetal-cloud-servers.md
@@ -14,17 +14,9 @@ OnMetal Cloud Servers enables you to boot bare metal servers via the
 Rackspace Cloud Control Panel interface. Use the following steps to set
 up an OnMetal server through the Control Panel.
 
--   [Create an OnMetal cloud server in the Cloud Control Panel](#create)
--   [Boot the server](#boot)
--   [Log in to or delete the server](#login)
--   [Using OnMetal](#usintOnmetal)
+**Note:** For the parallel steps in the API, see [Using OnMetal Cloud Servers through the API](/how-to/using-onmetal-cloud-servers-through-api).
 
-**Note:** For the parallel steps in the API, see [Using OnMetal Cloud
-Servers through the
-API](/how-to/using-onmetal-cloud-servers-through-api).
-
-Create an OnMetal server in the Cloud Control Panel
--------------------------------------------------------
+### Create an OnMetal server in the Cloud Control Panel
 
 1.  Log in to the [Cloud Control Panel.](http://mycloud.rackspace.com)
 
@@ -77,15 +69,13 @@ Create an OnMetal server in the Cloud Control Panel
 13. As needed, create a new network and select the PublicNet and
     ServiceNet options.
 14. Click **Create Server**.
-    <span>Your server is built.</span>
+    Your server is built.
 
-Boot the server
--------------------
+### Boot the server
 
 1.  On the details page for your server, click the link under **Log Into
     Your Server Now** in the right-hand column. For more information,
-    see [Connecting to a server using SSH on Linux or Mac OS for further
-    information](/how-to/connecting-to-a-server-using-ssh-on-linux-or-mac-os).
+    see [Connecting to a server using SSH on Linux or Mac OS for further information](/how-to/connecting-to-a-server-using-ssh-on-linux-or-mac-os).
 2.  Use the following command to boot your OnMetal server.
 
         supernova iad boot --flavor flavorId --image imageId --key-name keyName serverName
@@ -96,31 +86,31 @@ Boot the server
 
     You should see output similar to the following example:
 
-            +------------------------+--------------------------------------+
-            | Property | Value |
-            +------------------------+--------------------------------------+
-            | status | BUILD |
-            | updated | 2014-05-31T00:23:29Z |
-            | OS-EXT-STS:task_state | scheduling |
-            | key_name | johndoe |
-            | image | OnMetal - Debian 7 (Wheezy) |
-            | hostId | |
-            | OS-EXT-STS:vm_state | building |
-            | flavor | OnMetal I/O v1 |
-            | id | a8ea2366-9e50-4604-b6ce-e3edb8750451 |
-            | user_id | 83362 |
-            | name | teeth5 |
-            | adminPass | 6FgtaEqkapRo |
-            | tenant_id | 545251 |
-            | created | 2014-05-31T00:23:29Z |
-            | OS-DCF:diskConfig | MANUAL |
-            | accessIPv4 | |
-            | accessIPv6 | |
-            | progress | 0 |
-            | OS-EXT-STS:power_state | 0 |
-            | config_drive | |
-            | metadata | {} |
-            +------------------------+--------------------------------------+
+        +------------------------+--------------------------------------+
+        | Property               | Value                                |
+        +------------------------+--------------------------------------+
+        | status                 | BUILD                                |
+        | updated                | 2014-05-31T00:23:29Z                 |
+        | OS-EXT-STS:task_state  | scheduling                           |
+        | key_name               | johndoe                              |
+        | image                  | OnMetal - Debian 7 (Wheezy)          |
+        | hostId                 |                                      |
+        | OS-EXT-STS:vm_state    | building                             |
+        | flavor                 | OnMetal I/O v1                       |
+        | id                     | a8ea2366-9e50-4604-b6ce-e3edb8750451 |
+        | user_id                | 83362                                |
+        | name                   | teeth5                               |
+        | adminPass              | 6FgtaEqkapRo                         |
+        | tenant_id              | 545251                               |
+        | created                | 2014-05-31T00:23:29Z                 |
+        | OS-DCF:diskConfig      | MANUAL                               |
+        | accessIPv4             |                                      |
+        | accessIPv6             |                                      |
+        | progress               | 0                                    |
+        | OS-EXT-STS:power_state | 0                                    |
+        | config_drive           |                                      |
+        | metadata               | {}                                   |
+        +------------------------+--------------------------------------+
 
     **Note:** Although this output displays an admin password, this
     password is not actually used. You can safely ignore it.
@@ -132,33 +122,32 @@ Boot the server
 
     The output should look like the following example:
 
-            +------------------------+--------------------------------------------------------------------+
-
-            | Property | Value |
-            +------------------------+--------------------------------------------------------------------+
-            | status | ACTIVE |
-            | updated | 2014-05-31T00:27:34Z |
-            | OS-EXT-STS:task_state | None |
-            | private network | 10.184.0.48 |
-            | key_name | johndoe |
-            | image | OnMetal - Debian 7 (Wheezy) (1387253c-7735-4542-9612-26bc9ff77a9d) |
-            | hostId | 8a12611e45a1e15a1aec221ab05c8494524d6bf00e7fb17c5c82722a |
-            | OS-EXT-STS:vm_state | active |
-            | public network | 23.253.157.48 |
-            | flavor | OnMetal I/O v1 (onmetal-io1) |
-            | id | a8ea2366-9e50-4604-b6ce-e3edb8750451 |
-            | user_id | 83362 |
-            | name | teeth5 |
-            | created | 2014-05-31T00:23:29Z |
-            | tenant_id | 545251 |
-            | OS-DCF:diskConfig | MANUAL |
-            | accessIPv4 | 23.253.157.48 |
-            | accessIPv6 | |
-            | progress | 0 |
-            | OS-EXT-STS:power_state | 1 |
-            | config_drive | |
-            | metadata | {} |
-            +------------------------+--------------------------------------------------------------------+
+        +------------------------+--------------------------------------------------------------------+
+        | Property               | Value                                                              |
+        +------------------------+--------------------------------------------------------------------+
+        | status                 | ACTIVE                                                             |
+        | updated                | 2014-05-31T00:27:34Z                                               |
+        | OS-EXT-STS:task_state  | None                                                               |
+        | private network        | 10.184.0.48                                                        |
+        | key_name               | johndoe                                                            |
+        | image                  | OnMetal - Debian 7 (Wheezy) (1387253c-7735-4542-9612-26bc9ff77a9d) |
+        | hostId                 | 8a12611e45a1e15a1aec221ab05c8494524d6bf00e7fb17c5c82722a           |
+        | OS-EXT-STS:vm_state    | active                                                             |
+        | public network         | 23.253.157.48                                                      |
+        | flavor                 | OnMetal I/O v1 (onmetal-io1)                                       |
+        | id                     | a8ea2366-9e50-4604-b6ce-e3edb8750451                               |
+        | user_id                | 83362                                                              |
+        | name                   | teeth5                                                             |
+        | created                | 2014-05-31T00:23:29Z                                               |
+        | tenant_id              | 545251                                                             |
+        | OS-DCF:diskConfig      | MANUAL                                                             |
+        | accessIPv4             | 23.253.157.48                                                      |
+        | accessIPv6             |                                                                    |
+        | progress               | 0                                                                  |
+        | OS-EXT-STS:power_state | 1                                                                  |
+        | config_drive           |                                                                    |
+        | metadata               | {}                                                                 |
+        +------------------------+--------------------------------------------------------------------+
 
     Within a few minutes, the server is assigned public and private IP
     addresses, which you can see in the output of the `show` command.
@@ -166,8 +155,7 @@ Boot the server
     first time. The server is not reachable, however, until the network
     configuration is complete, which might take another few minutes.
 
-Log in to the server
-------------------------
+### Log in to the server
 
 After the server has booted, use the SSH key pair that you specified to
 log in to the server.
@@ -176,13 +164,12 @@ log in to the server.
 
     ssh root@publicIpAddress
 
-Delete the server
----------------------
+### Delete the server
 
 If needed, you can also delete or cancel the server.
 
 1.  Run the following command, replacing the example ID with your
-    server&rsquo;s ID:
+    server's ID:
 
         supernova iad delete a8ea2366-9e50-4604-b6ce-e3edb8750451
 
@@ -192,21 +179,18 @@ If needed, you can also delete or cancel the server.
 
     The output should look similar to the following example:
 
-            +--------------------------------------+---------+--------+------------+-------------+---------------------------------------------+
-            | ID | Name | Status | Task State | Power State | Networks |
-            +--------------------------------------+---------+--------+------------+-------------+---------------------------------------------+
-            | d1d58868-2b14-4fa5-b01f-e51d658556a8 | highcpu | ACTIVE | deleting | Running | public=23.253.157.105; private=10.184.0.105 |
-            +--------------------------------------+---------+--------+------------+-------------+---------------------------------------------+
+        +--------------------------------------+---------+--------+------------+-------------+---------------------------------------------+
+        | ID | Name | Status | Task State | Power State | Networks |
+        +--------------------------------------+---------+--------+------------+-------------+---------------------------------------------+
+        | d1d58868-2b14-4fa5-b01f-e51d658556a8 | highcpu | ACTIVE | deleting | Running | public=23.253.157.105; private=10.184.0.105 |
+        +--------------------------------------+---------+--------+------------+-------------+---------------------------------------------+
 
     **Note:** Your server goes into the task state deleting. OnMetal
     server deletions take longer than virtual server deletions, usually
     a few minutes.
 
-Using OnMetal
------------------
+### Using OnMetal
 
 The flash cards included with the OnMetal I/O flavor are unformatted.
 You can RAID and format them however you like. For more information, see
-[Configure flash drives in High I/O instances as Data
-drives](/how-to/configure-flash-drives-in-high-io-instances-as-data-drives).
-
+[Configure flash drives in High I/O instances as Data drives](/how-to/configure-flash-drives-in-high-io-instances-as-data-drives).

--- a/content/cloud-servers/creating-a-general-purpose-cloud-server.md
+++ b/content/cloud-servers/creating-a-general-purpose-cloud-server.md
@@ -12,25 +12,20 @@ product_url: cloud-servers
 
 This article explains how to set up a General Purpose cloud server
 through the Cloud Control Panel interface. For more information about
-General Purpose servers, see [New Features in General Purpose and
-Work-Optimized Cloud
-Servers](/how-to/new-features-in-general-purpose-and-work-optimized-cloud-servers).
+General Purpose servers, see [New Features in General Purpose and Work-Optimized Cloud Servers](/how-to/new-features-in-general-purpose-and-work-optimized-cloud-servers).
 
-1.  Log in to the [Cloud
-    Control Panel.](https://mycloud.rackspace.com)
+1.  Log in to the [Cloud Control Panel.](https://mycloud.rackspace.com)
 
-2.  [Create a server from a saved image](#fromsavedimage), or [create a
-    new server](#createnew).
+2.  Create a server from a saved image, or create a new server.
     -   To create a server from a previously saved image,
-        select **Servers &gt; Saved Images**. Click the gear icon next
+        select **Servers > Saved Images**. Click the gear icon next
         to the image that you want to use to create the server, and
         select **Create Server with Image**. Skip to step 3.
 
         ![](https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/SavedImages.png)
 
-    -   To create a new server, select **Cloud Servers &gt; Create
+    -   To create a new server, select **Cloud Servers > Create
         Servers**, and then click **Create Server**.
-
 
 3.  In the **Server Details** section of the Create Servers page, enter
     a name for your server in the **Server Name** field.
@@ -42,7 +37,7 @@ Servers](/how-to/new-features-in-general-purpose-and-work-optimized-cloud-server
     center in Chicago, Illinois, USA, or select **Sydney (SYD)** for a
     data center in Sydney, Australia.
 
-5.  Under **Image** select which OS you want to uset. If you are
+5.  Under **Image** select which OS you want to use. If you are
     creating the server from a saved image, the image is already
     selected.
 
@@ -63,5 +58,3 @@ Servers](/how-to/new-features-in-general-purpose-and-work-optimized-cloud-server
 10. After your server is created, its status is displayed as Active. You
     can then log in to it by using Remote Desktop Protocol (RDP) or SSH,
     depending on your server's OS.
-
-

--- a/content/cloud-servers/creating-an-image-backup-cloning.md
+++ b/content/cloud-servers/creating-an-image-backup-cloning.md
@@ -9,59 +9,35 @@ last_modified_by: Nate Archer
 product: Cloud Servers
 product_url: cloud-servers
 ---
+This article guides you through the process of
+creating an image backup (cloning).
 
-<span><span><span>This article guides you through the process of
-creating an image backup (cloning).</span></span></span>
-
-<span><span><span>**Note:** ** While you can create a different size
+**Note:** While you can create a different size
 server from that of the saved image, you must still use the same base OS
-version. </span></span></span>
+version.
 
-<span><span><span>**Note:** ** The first part of the procedure takes you
+**Note:** The first part of the procedure takes you
 through creating a snapshot image; if your snapshot image has already
-been created, you can skip to
-</span></span></span><span><span><span>[Restoring A Server From A Saved
-Image](#A).</span></span></span>
+been created, you can skip to Restoring a Ssrver from a saved
+image.
 
-<span><span><span>1. Log into the Cloud Control
-Panel.</span></span></span>
+1. Log into the [Cloud Control Panel](http://mycloud.rackspace.com).
 
-![](http://c15149618.r18.cf2.rackcdn.com/1.png)
+  ![](http://c15149618.r18.cf2.rackcdn.com/1.png)
 
-<div>
-
-
-
-</div>
-
-<div>
-
-2\. Select the server that you want to clone by clicking the actions cog
+2. Select the server that you want to clone by clicking the actions cog
 to the left of the server name.
 
 3. From the drop-down menu, click **Create Image**.
 
-</div>
+  ![](http://c15149618.r18.cf2.rackcdn.com/3B.png)
 
+  A pop-up window will appear that allows you to name the image.
 
+4. After naming the image, click the **Create Image** button.
 
-![](http://c15149618.r18.cf2.rackcdn.com/3B.png)
+  <img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/Feb%2012%20-%20Create%20image_2.png" width="266" height="220" />
 
--   A pop-up window will appear that allows you to name the image.
-
-
-
-4\. After naming the image, click the **Create Image** button.
-
-<img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/Feb%2012%20-%20Create%20image_2.png" width="266" height="220" />
-
-
-
--   Server images will appear in the **Images** list after they have
-    been created. They can be accessed by clicking on the **View
-    Images** in the **Images** section.
+Server images will appear in the **Images** list after they have been created. They can be accessed by clicking on the **View Images** in the **Images** section.
 
 <img src="https://8026b2e3760e2433679c-fffceaebb8c6ee053c935e8915a3fbe7.ssl.cf2.rackcdn.com/field/image/Feb%2012%20-%20View%20Images.png" width="513" height="106" />
-
-
-


### PR DESCRIPTION
part 9? of the servers content audit: moved networks and DNS articles to their appropriate home, fixed a lot of header levels, formatting for bulleted and numbered lists, code, images, and links.