### PR TITLE
Fix markdown numbering.

### DIFF
--- a/content/cloud-networks/configuring-interface-based-firewall-on-the-vyatta-network-appliance.md
+++ b/content/cloud-networks/configuring-interface-based-firewall-on-the-vyatta-network-appliance.md
@@ -116,7 +116,7 @@ interface of the Vyatta. This rule set does the following:
 -   Allows SSH and ICMP traffic
 
 
-1. Log onto the Vyatta Appliance using ssh:
+(1) Log onto the Vyatta Appliance using ssh:
 
         ssh vyatta@X.X.X.X
 
@@ -126,7 +126,7 @@ Vyatta message and a prompt to enter your Vyatta password.
   Once you're logged onto the appliance, you can enter a ? or press the
 Tab key for help.
 
-2. Enter configuration mode:
+(2) Enter configuration mode:
 
        vyatta@vyatta: configure
        [edit]
@@ -134,12 +134,12 @@ Tab key for help.
 
   The \# symbol indicates you're in configuration mode.
 
-3. Make the firewall stateful (global configuration)
+(3) Make the firewall stateful (global configuration)
 
        set firewall state-policy established action 'accept'
        set firewall state-policy related action 'accept'
 
-4. Set the recommended global rules which will apply to all firewall
+(4) Set the recommended global rules which will apply to all firewall
 protected interfaces. Anything global can be changed within the
 interface specific firewall rule
 
@@ -154,7 +154,7 @@ interface specific firewall rule
        set firewall source-validation 'disable'
        set firewall syn-cookies 'enable'
 
-5. Start configuring firewall configuration for Public interface
+(5) Start configuring firewall configuration for Public interface
 
         edit firewall name protect-vyatta
 
@@ -205,18 +205,18 @@ interface specific firewall rule
        set rule 900 protocol 'icmp'
        exit
 
-6. Apply locally on Public interface (eth0)
+(6) Apply locally on Public interface (eth0)
 
        set interfaces ethernet eth0 firewall local name 'protect-vyatta'
 
-7. Create and apply firewall ruleset 'in' (for traffic destined for
+(7) Create and apply firewall ruleset 'in' (for traffic destined for
 cloud servers) on Public interface (eth0)
 
        set firewall name untrusted default-action 'drop'
        set firewall name untrusted description 'deny traffic from internet'
        set interfaces ethernet eth0 firewall in name 'untrusted'
 
-8. Commit and save the changes.
+(8) Commit and save the changes.
 
        commit
        save


### PR DESCRIPTION
Issues were arising from standard text and cod examples within the ordered list of steps. Enclosed numbers in paren to adapt.