### PR TITLE
removing link to unmigrated article

### DIFF
--- a/content/cloud-servers/basic-settings-in-the-postfix-maincf-file.md
+++ b/content/cloud-servers/basic-settings-in-the-postfix-maincf-file.md
@@ -217,4 +217,4 @@ domain. Check the headers to verify that they are correct.
 Configuring Postfix can be a daunting task. This introduction helps with
 the basics and shows how using variables instead of hard coding domain
 names can save time and effort in any future
-administration. For more information on using Postfix, see [Creating DNS records and receiving emails via PostFix](/how-to/creating-dns-records-and-receiving-emails-via-postfix).
+administration. 


### PR DESCRIPTION
The published version on the KC doesn't have this link, so I'm not sure how it squeaked through. I've removed it.