### PR TITLE
Update create-a-rackspace-cdn-service.md

### DIFF
--- a/content/rackspace-cdn/create-a-rackspace-cdn-service.md
+++ b/content/rackspace-cdn/create-a-rackspace-cdn-service.md
@@ -102,7 +102,7 @@ After you have configured the website and before you update your DNS
 records, test that the web server is responding by using a cURL
 statement similar to the following one:
 
-    curl -I -k &ndash;H "Host:cdn.customer.com.cdn306.raxcdn.com" https://SERVER_IP/
+    curl -I -k -H "Host:cdn.customer.com.cdn306.raxcdn.com" https://SERVER_IP/
 
 The response should be `HTTP/1.1 200 OK`.
 


### PR DESCRIPTION
Hello Knowledge Center team,
I think I have found an issue with the article
https://support.rackspace.com/how-to/create-a-rackspace-cdn-service/

I think there is an issue with the way the site is displaying the curl command example:
curl -I -k&ndash;H "Host:cdn.customer.com.cdn306.raxcdn.com" https://SERVER_IP/
I think it should be:
curl -I -k -H "Host:cdn.customer.com.cdn306.raxcdn.com" https://SERVER_IP/

Thank you for your help, please let me know if you have any questions.
Weston Pierry 
Escalation Support for Cloud