### PR TITLE
Update docs links#411

### DIFF
--- a/content/cloud-big-data/cloud-big-data-platform-provisioning-and-pricing.md
+++ b/content/cloud-big-data/cloud-big-data-platform-provisioning-and-pricing.md
@@ -17,7 +17,7 @@ new nodes on the configuration. The provisioning of resources in Cloud
 Big Data Platform can be done easily via the Rackspace Cloud Control
 Panel or API. For more information about how to get started using Cloud
 Big Data Platform, see the [Getting
-Started](http://docs.rackspace.com/cbd/api/v1.0/cbd-getting-started/content/CBD_Overview.html)
+Started](https://developer.rackspace.com/docs/cloud-big-data/v2/developer-guide/#getting-started)
 Guide.
 
 Although Cloud Big Data Platform uses a standard and common Apache
@@ -150,4 +150,3 @@ We hope that these additional points help you successfully understand
 and deploy your Cloud Big Data solution. If you need help, reach out to
 our data specialist support team by creating a ticket in the Rackspace
 Cloud Control Panel.
-

--- a/content/cloud-databases/cloud-databases-faq.md
+++ b/content/cloud-databases/cloud-databases-faq.md
@@ -324,7 +324,7 @@ based on instance size.
 
 Release notes, API documentation, and a getting started guide for Cloud
 Databases are all available on the Rackspace [API Documentation
-site](http://docs.rackspace.com/api/).
+site](https://developer.rackspace.com/docs/).
 
 #### Are there API or account limits for my Cloud Database instances?
 
@@ -541,4 +541,3 @@ Pricing information is available at [the Cloud Databases pricing
 page](http://www.rackspace.com/cloud/databases/pricing/). Standard
 charges apply for any Cloud Servers, Cloud Load Balancers, or Cloud
 Sites that are used to access your Cloud Database instances.
-

--- a/content/cloud-databases/cloud-databases.md
+++ b/content/cloud-databases/cloud-databases.md
@@ -30,5 +30,5 @@ product_url: cloud-databases
 
 ###  Cloud Databases API
 
-- [Getting Started with the Cloud Databases API](http://docs.rackspace.com/cdb/api/v1.0/cdb-getting-started/content/DB_Overview.html)
-- [Cloud Databases API Developer's Guide](http://docs.rackspace.com/cdb/api/v1.0/cdb-devguide/content/overview.html)
+- [Getting Started with the Cloud Databases API](https://developer.rackspace.com/docs/cloud-databases/v1/developer-guide/#getting-started)
+- [Cloud Databases API Developer's Guide](https://developer.rackspace.com/docs/cloud-databases/v1/developer-guide/)

--- a/content/cloud-databases/monitoring-cloud-databases-in-the-cloud-control-panel.md
+++ b/content/cloud-databases/monitoring-cloud-databases-in-the-cloud-control-panel.md
@@ -128,7 +128,7 @@ You can view and create alarms from a check's details page.
 
     The language used to define criteria for alarms is documented in the
     [Alert Triggering and
-    Alarms](http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/appendix-check-types-agent.html)
+    Alarms](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#document-tech-ref-info/alert-triggers-and-alarms)
     section of the Cloud Monitoring API documentation. Clicking Example
     Alarm under the criteria field will let you view example criteria
     for the check.

--- a/content/cloud-files/cloud-files.md
+++ b/content/cloud-files/cloud-files.md
@@ -21,8 +21,8 @@ Store it on Cloud Files, serve it fast on Akamai's CDN. Cloud Files, powered by 
 
 ###  Cloud Files API and SDKs
 
-- [Cloud Files API Getting Started Guide](http://docs.rackspace.com/files/api/v1/cf-getting-started/content/Overview-d1e01.html)
-- [Cloud Files Developer Guide](http://docs.rackspace.com/files/api/v1/cf-devguide/content/index.html)
+- [Cloud Files API Getting Started Guide](https://developer.rackspace.com/docs/cloud-files/v1/developer-guide/#getting-started)
+- [Cloud Files Developer Guide](https://developer.rackspace.com/docs/cloud-files/v1/developer-guide/#document-developer-guide)
 - [Java SDK for Rackspace Cloud](https://developer.rackspace.com/sdks/java/)
 - [PHP SDK for Rackspace Cloud](https://developer.rackspace.com/sdks/php/)
 - [Python SDK for Rackspace Cloud](https://developer.rackspace.com/sdks/python/)

--- a/content/cloud-files/mounting-rackspace-cloud-files-to-linux-using-cloudfuse.md
+++ b/content/cloud-files/mounting-rackspace-cloud-files-to-linux-using-cloudfuse.md
@@ -127,7 +127,7 @@ You'll have to create a configuration file for CloudFuse in your home directory 
 
 ### Auth URLs:
 
-Cloud Files account: [https://auth.api.rackspacecloud.com/v1.0](http://docs.rackspace.com/files/api/v1/cf-devguide/content/)
+Cloud Files account: [https://auth.api.rackspacecloud.com/v1.0](https://developer.rackspace.com/docs/cloud-files/v1/developer-guide/#document-developer-guide)
 
 The following entries are optional. You can define these values in the .cloudfuse file.
 

--- a/content/cloud-files/streaming-cloud-files-with-jw-player.md
+++ b/content/cloud-files/streaming-cloud-files-with-jw-player.md
@@ -58,7 +58,7 @@ From the *Cloud Control Panel*:
 3.  Click the "Publish to CDN" button to confirm.
 
 From *the API*, see [the API Dev Guide section, "CDN-Enable a
-Container"](http://docs.rackspace.com/files/api/v1/cf-devguide/content/PUT_enableDisableCDNcontainer_v1__account___container__CDN_Container_Services-d1e2632.html).
+Container"](https://developer.rackspace.com/docs/cloud-files/v1/developer-guide/#cdn-enabling-the-container-and-setting-a-ttl).
 
 
 
@@ -124,6 +124,3 @@ This SCRIPT uses the following options:
             primary: 'flash'
         });
      </script>
-
-
-

--- a/content/cloud-files/use-swiftly-to-upload-an-image.md
+++ b/content/cloud-files/use-swiftly-to-upload-an-image.md
@@ -28,7 +28,7 @@ GB to Cloud Files as a Static Large Object.
 
 For more information about Cloud Files Large Objects, see the [Cloud
 Files
-documentation](http://docs.rackspace.com/files/api/v1/cf-devguide/content/Overview-d1e70.html).
+documentation](https://developer.rackspace.com/docs/cloud-files/v1/developer-guide/).
 
 Prerequisites
 -------------

--- a/content/cloud-images/identifying-rackspace-standard-images.md
+++ b/content/cloud-images/identifying-rackspace-standard-images.md
@@ -36,15 +36,15 @@ choosing the base image to list only standard images.
 #### Cloud Servers API
 
 You can identify standard images when using the [Cloud Servers API
-v2](http://docs.rackspace.com/servers/api/v2/cs-devguide/content/index.html "Rackspace Cloud Servers API documentation")
+v2](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/)
 by making a [List Images
-request](http://docs.rackspace.com/servers/api/v2/cs-devguide/content/List_Images-d1e4435.html) and
+request](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#document-getting-started/create-server/list-images) and
 filtering it to list images that have their `type` value set to `BASE`.
 
 #### Cloud Images API
 
 You can identify standard images when using the [Cloud Images API
-v2](http://docs.rackspace.com/images/api/v2/ci-devguide/content/index.html "Rackspace Cloud Images API documentation")
+v2](https://developer.rackspace.com/docs/cloud-images/v2/developer-guide/)
 by making a List Images request and filtering it to list images that
 have their `visibility` value set to `public`.
 

--- a/content/cloud-images/transferring-images-between-regions-of-the-rackspace-open-cloud.md
+++ b/content/cloud-images/transferring-images-between-regions-of-the-rackspace-open-cloud.md
@@ -37,7 +37,7 @@ Before we get into the details, consider the following information:
     in the Cloud Images FAQ for details.
 -   Cloud Images is currently accessible only through the [Cloud Images
     v2
-    API](http://docs.rackspace.com/images/api/v2/ci-devguide/content/ch_image_preface.html);
+    API](https://developer.rackspace.com/docs/cloud-images/v2/developer-guide/);
     it's not available in the Cloud Control Panel yet.
 -   Cloud Images uses only JSON; it does not use XML.
 
@@ -275,6 +275,6 @@ can import it for use with Cloud Servers.
 ### Related information
 
 -   [Rackspace Cloud Images Developer
-    Guide](http://docs.rackspace.com/images/api/v2/ci-devguide/content/index.html)
+    Guide](https://developer.rackspace.com/docs/cloud-images/v2/developer-guide/)
 -   [Cloud Images
     FAQ](/how-to/cloud-images-faq)

--- a/content/cloud-load-balancers/content-caching-for-cloud-load-balancers.md
+++ b/content/cloud-load-balancers/content-caching-for-cloud-load-balancers.md
@@ -17,7 +17,7 @@ by web clients.
 ### How do I enable content caching?
 
 Content caching can be enabled through our [Cloud Load Balancers
-API](http://docs.rackspace.com/loadbalancers/api/v1.0/clb-devguide/content/index.html) or
+API](https://developer.rackspace.com/docs/cloud-load-balancers/v1/developer-guide/) or
 the [Cloud Control Panel](https://mycloud.rackspace.com).
 
 Content caching can be enabled or disabled for a load balancer in the
@@ -127,6 +127,3 @@ the following to your apache config:
 Replace the extensions in the &ldquo;ico|flv|jpg|jpeg&rdquo; section with the
 extensions for which you want to bypass caching, making sure to put a
 &ldquo;|&rdquo; character between each extension.
-
-
-

--- a/content/cloud-monitoring/alarm-language-generic-thresholds-made-easy.md
+++ b/content/cloud-monitoring/alarm-language-generic-thresholds-made-easy.md
@@ -37,7 +37,7 @@ Monitoring lets you:
 -   See the solution patterns in our best practices documentation and
     then easily create your own complex alarms. Our API makes it simple
     to keep up to date on these examples, get more information
-    [here](http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/service-alarm-examples.html).
+    [here](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#document-api-operations/alarm-example-operations).
 -   Put developers in control by letting them build thresholds similar
     to how you create your application code.
 -   Test thresholds before you configure them. Use data from our [Test

--- a/content/cloud-monitoring/getting-started-with-rackspace-monitoring-cli.md
+++ b/content/cloud-monitoring/getting-started-with-rackspace-monitoring-cli.md
@@ -81,13 +81,12 @@ triggers an alert if the response is something like a 404.
 Raxmon mostly follows CRUD methodology, Create, Read (list), Update,
 Delete with five types:
 
--   [Checks](http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/service-checks.html)
--   [Entities](http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/service-entities.html)
--   [Alarms](http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/service-alarms.html)
--   [Notifications](http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/service-notifications.html)
+-   [Checks](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#document-api-operations/check-operations)
+-   [Entities](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#document-api-operations/entities-operations)
+-   [Alarms](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#document-api-operations/alarms-operations)
+-   [Notifications](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#document-api-operations/notifications-operations)
 -   
-[Notification
-    Plans](http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/service-notification-plans.html)
+[Notification Plans](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#document-api-operations/notification-plans-operations)
 
 Type \$ **raxmon --help** to see all of the commands available to
 raxmon.

--- a/content/cloud-monitoring/rackspace-monitoring-checks-and-alarms.md
+++ b/content/cloud-monitoring/rackspace-monitoring-checks-and-alarms.md
@@ -44,7 +44,7 @@ Each check and alarm has selectable options.
 
 The checks are defined below. For the official definitions, see the
 Rackspace Monitoring Developer guide [Available Check Types and
-Fields.](http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/appendix-check-types.html "Check type documentation")
+Fields.](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#document-tech-ref-info/check-type-reference)
 Please note, only those checks listed below are available through the
 control panel. Checks not available in the control panel are noted.
 

--- a/content/cloud-queues/cloud-queues-curl-cookbook.md
+++ b/content/cloud-queues/cloud-queues-curl-cookbook.md
@@ -294,8 +294,7 @@ at the number of messages free vs. the total.
 **Please Note**: We have additional developer information available in
 our API documentation.  Listed under Other Products, we have a [Getting
 Started
-Guide](http://docs.rackspace.com/queues/api/v1.0/cq-gettingstarted/content/DB_Overview.html)
+Guide](https://developer.rackspace.com/docs/cloud-queues/v1/developer-guide/#getting-started)
 and an [API Developer
-Guide](http://docs.rackspace.com/queues/api/v1.0/cq-devguide/content/overview.html)
+Guide](https://developer.rackspace.com/docs/cloud-queues/v1/developer-guide/#document-developer-guide)
 for Cloud Queues.
-

--- a/content/cloud-queues/tips-for-monitoring-your-queues-in-cloud-queues.md
+++ b/content/cloud-queues/tips-for-monitoring-your-queues-in-cloud-queues.md
@@ -10,9 +10,9 @@ product: Cloud Queues
 product_url: cloud-queues
 ---
 
-**Note:** Be sure to set up your [authentication token](/how-to/cloud-queues-curl-cookbook) before following the steps to create a queue by submitting an API request from the terminal. 
+**Note:** Be sure to set up your [authentication token](/how-to/cloud-queues-curl-cookbook) before following the steps to create a queue by submitting an API request from the terminal.
 
-Use the following procedures to get queue statistics, including the number of messages that exist in the queue, and the number of messages for each message status. 
+Use the following procedures to get queue statistics, including the number of messages that exist in the queue, and the number of messages for each message status.
 
 ### Monitoring through the API
 
@@ -67,4 +67,4 @@ You can view statistics for a queue in the Cloud Control Panel.
 
 **Note:** If total is 0, the display does not include statistics for *oldest* and *newest* messages.
 
-You can find more developer information in the [Getting Started Guide](http://docs.rackspace.com/queues/api/v1.0/cq-gettingstarted/content/DB_Overview.html) and [API Developer Guide for Cloud Queues](http://docs.rackspace.com/queues/api/v1.0/cq-devguide/content/overview.html).
+You can find more developer information in the [Getting Started Guide](https://developer.rackspace.com/docs/cloud-queues/v1/developer-guide/#getting-started) and [API Developer Guide for Cloud Queues](https://developer.rackspace.com/docs/cloud-queues/v1/developer-guide/#document-developer-guide).

--- a/content/cloud-servers/boot-a-server-from-a-cloud-block-storage-volume.md
+++ b/content/cloud-servers/boot-a-server-from-a-cloud-block-storage-volume.md
@@ -26,7 +26,7 @@ Booting from a Cloud Block Storage volume provides the following benefits:
 - **Scale** &ndash; If you want to change the size of your server, you can easily delete your existing server and create a new one by using the same volume in Cloud Block Storage. If the IP address is important to your use case, we recommend placing a load balancer in front of the server.
 - **Flexibility** &ndash; You have control over the size and type (SSD or SATA) of volume that you use to boot your server. This control enables you to fine-tune the storage to the needs of your operating system or application.
 
-You can get started through the [Control Panel](https://mycloud.rackspace.com) or through the [API](http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/overview.html).
+You can get started through the [Control Panel](https://mycloud.rackspace.com) or through the [API](https://developer.rackspace.com/docs/cloud-block-storage/v1/developer-guide/).
 
 ### Setup options
 

--- a/content/cloud-servers/detailed-permissions-matrix-for-dns.md
+++ b/content/cloud-servers/detailed-permissions-matrix-for-dns.md
@@ -76,7 +76,7 @@ Subdomains are domains within a parent domain, and subdomains cannot be register
 
 ### Related articles
 
--  [API Documentation](http://docs.rackspace.com/)
+-  [API Documentation](https://developer.rackspace.com/docs/)
 -  [Related Knowledge Center Articles](/how-to/)
 -  [Cloud DNS Terminology](/how-to/detailed-permissions-matrix-for-dns)
 -  [Permission Matrices for RBAC](/how-to/permissions-matrix-for-role-based-access-control-rbac)

--- a/content/cloud-servers/faq-for-seamless-sign-on-between-myrackspace-and-the-cloud-control-panel.md
+++ b/content/cloud-servers/faq-for-seamless-sign-on-between-myrackspace-and-the-cloud-control-panel.md
@@ -135,7 +135,7 @@ functionality, there are 3 options:
     work with metadata, and more. See the [Python Nova Client command reference](/how-to/useful-python-novaclient-commands)
     for more information.
 2.  Use the Cloud Servers API to specify your server's metadata. The
-    [Cloud Servers Developer Guide](http://docs.rackspace.com/servers/api/v2/cs-devguide/content/Create_or_Replace_Metadata-d1e5358.html)
+    [Cloud Servers Developer Guide](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#set-server-metadata)
     provides instructions on how to do this.
 3.  Enlist your Rackspace Support team by phone or ticket to make these
     changes on your behalf.

--- a/content/cloud-servers/getting-started-with-cloud-servers.md
+++ b/content/cloud-servers/getting-started-with-cloud-servers.md
@@ -31,7 +31,7 @@ The following concepts will help you in getting started quickly:
     Windows and Linux servers will be accessible through a web console
     from our Control Panel as well.
 -   Customers can manage Cloud Servers through the [Control Panel](https://manage.rackspacecloud.com), or an
-    [API](http://docs.rackspace.com)(Application Programming Interface).
+    [API](https://developer.rackspace.com/docs/)(Application Programming Interface).
 -   The hardware that hosts your Cloud Server can be located
     in: Dallas/Ft. Worth, TX - Chicago, IL - or in London, England
     ([UK](http://www.rackspace.co.uk/cloud-hosting/cloud-products/cloud-servers/)).

--- a/content/cloud-servers/manage-ssh-key-pairs-for-cloud-servers-with-python-novaclient.md
+++ b/content/cloud-servers/manage-ssh-key-pairs-for-cloud-servers-with-python-novaclient.md
@@ -22,7 +22,7 @@ For more information about using SSH to connect to servers, see the following ar
 
 This article discusses using the python-novaclient command-line tool to generate a key pair and assign its public key to a Linux server when the server is created.
 
-You can also manage key pairs directly by using the [Cloud Servers API](http://docs.rackspace.com/servers/api/v2/cs-devguide/content/ServersKeyPairs-d1e2545.html).
+You can also manage key pairs directly by using the [Cloud Servers API](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#create-a-server-key-pair).
 
 ### Prepare python-novaclient
 

--- a/content/cloud-servers/using-python-novaclient-to-manage-scheduled-images.md
+++ b/content/cloud-servers/using-python-novaclient-to-manage-scheduled-images.md
@@ -274,4 +274,4 @@ done through the API or python-novaclient.
 -   [Scheduled Images
     FAQ](/how-to/scheduled-images-faq "Scheduled Images FAQ")
 -   [Scheduled Images API Extension
-    Documentation](http://docs.rackspace.com/servers/api/v2/cs-devguide/content/ch_extensions.html#scheduled_images)
+    Documentation](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#document-extensions/ext-scheduled-images)

--- a/content/general/known-issues-and-suggested-workarounds-role-based-access-control-rbac.md
+++ b/content/general/known-issues-and-suggested-workarounds-role-based-access-control-rbac.md
@@ -42,12 +42,12 @@ by contacting Support at 1-800-961-4454.
 ### Multiple Roles for One User
 
 **Known Issue:** Multiple roles for one user can only be assigned
-through the [API](http://docs.rackspace.com/). The Cloud Control Panel
+through the [API](https://developer.rackspace.com/docs/). The Cloud Control Panel
 displays only the first role assigned to users that have multiple
 roles.
 
 **Workaround:** A user's multiple roles can be viewed
-through the [API](http://docs.rackspace.com/).
+through the [API](https://developer.rackspace.com/docs/).
 
 ### Suspended Account
 

--- a/content/managed-operations/cloud-servers-with-managed-operations-support-for-linux.md
+++ b/content/managed-operations/cloud-servers-with-managed-operations-support-for-linux.md
@@ -95,7 +95,7 @@ The Managed Operations spheres of support include the following operating system
 
 While we do not support all technologies, we do offer reasonable endeavor support which extends our support into offering alternative solutions.  The reasonable endeavor support can include help from Rackspace partners and other third party services.
 
--  **API Support**  - Managed Operations offers all the support functions listed in the [developer guides](http://docs.rackspace.com/).
+-  **API Support**  - Managed Operations offers all the support functions listed in the [developer guides](https://developer.rackspace.com/docs/).
 -  **Cloud Files** -  Integration with Cloud Files is supported via the API, however no development assistance will be offered in utilization via the API.
 -  **Load Balancing** - Cloud Load Balancers are supported by Managed Operations.
 -  **Email**  - The default SMTP configuration for outbound email on Linux is through Postfix.  Cloud Servers with a Managed Operations service level are pre-configured to use our mail relay service Mailgun to ensure reliable mail delivery.  The first 50,000 emails sent each month are free, and your mail package can be upgraded if higher volume is expected. For more details see our [Mailgun Rackspace pricing page](http://www.mailgun.com/rackspace).

--- a/content/managed-operations/managed-operations-faq.md
+++ b/content/managed-operations/managed-operations-faq.md
@@ -89,7 +89,7 @@ For additional information, see the following Knowledge Center articles:
     Control
     Panel](/how-to/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image)
     or
-    [API](http://docs.rackspace.com/servers/api/v1.0/cs-devguide/content/Create_Image-d1e4206.html).
+    [API](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#create-image-of-specified-server).
 -   Rackspace Cloud Backup &mdash; Create and schedule [file-based
     backups](/how-to/rackspace-cloud-backup-overview).
 -   [Holland Backup Manager](http://hollandbackup.org/)&mdash; An open-source
@@ -164,11 +164,9 @@ Servers.
         Control
         Panel](/how-to/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image)
         or
-        [API](http://docs.rackspace.com/servers/api/v1.0/cs-devguide/content/Create_Image-d1e4206.html).
+        [API](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#create-image-of-specified-server).
     -   Rackspace Cloud Backup &mdash; Create and schedule [file-based
         backups](/how-to/rackspace-cloud-backup-overview).
     -   [Holland Backup Manager](http://hollandbackup.org/)&mdash; An
         open-source backup framework originally developed at Rackspace
         and written in Python.
-
-

--- a/content/rackconnect/getting-started-with-the-rackconnect-v30-api.md
+++ b/content/rackconnect/getting-started-with-the-rackconnect-v30-api.md
@@ -56,7 +56,7 @@ Your authentication token ID is sent within an `X-Auth-Token` header in
 your API calls. Details about obtaining your authentication token ID are
 located in the "Quick Start" section of the [Cloud Identity Client
 Developer
-Guide](http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/QuickStart-000.html).
+Guide](https://developer.rackspace.com/docs/cloud-identity/v2/developer-guide/).
 
 You can use either one of the following combinations of credentials to
 obtain your authentication token ID:

--- a/content/rackconnect/rackconnect-auto-nat-feature.md
+++ b/content/rackconnect/rackconnect-auto-nat-feature.md
@@ -29,7 +29,7 @@ assigned to a cloud server at build time.
     team will provide you with a list of Auto NAT Public IP addresses
     that have been allocated to you.
 - When creating new cloud servers, you must use the [Cloud Servers
-    API](http://docs.rackspace.com/servers/api/v2/cs-devguide/content/ch_preface.html)
+    API](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/)
     to enter the Metadata information required to assign an Auto NAT IP
     to a cloud server at build time
 - When creating a new cloud server you would like configured with an

--- a/content/rackconnect/rackconnect-v30-cloud-server-image-compatibility.md
+++ b/content/rackconnect/rackconnect-v30-cloud-server-image-compatibility.md
@@ -17,7 +17,7 @@ cloud server images listed as available in your RackConnect v3.0-enabled
 cloud account are compatible with RackConnect v3.0. You can see the list
 of cloud server images available for your cloud account by using the
 [Cloud Servers
-API](http://docs.rackspace.com/servers/api/v2/cs-gettingstarted/content/list_images.html),
+API](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#document-getting-started/create-server/list-images),
 or when you build a new cloud server in the [Cloud Control
 Panel](https://mycloud.rackspace.com/). RackConnect v3.0 is also
 compatible with all next generation Cloud Servers flavors, including

--- a/content/rackspace-auto-scale/cloud-bursting-using-auto-scale-rackconnect-and-f5-load-balancers.md
+++ b/content/rackspace-auto-scale/cloud-bursting-using-auto-scale-rackconnect-and-f5-load-balancers.md
@@ -52,7 +52,7 @@ Auto Scale:
      }
 
 For more information see the [Auto Scale API Developer Guide: Set Launch
-Configuration.](http://docs.rackspace.com/cas/api/v1.0/autoscale-devguide/content/Launch_Configuration.html)
+Configuration.](https://developer.rackspace.com/docs/autoscale/v1/developer-guide/#document-api-operations/configurations)
 
 ### Important notes
 


### PR DESCRIPTION
Change docs.rackspace references to point to DRC. 

Outstanding docs.rackspace references include: Cloud Feeds, RPC, VMWare, First Gen Cloud Server, and one code sample.