### PR TITLE
Warning to customers: CBU doesn't backup symlinks.

### DIFF
--- a/content/cloud-backup/rackspace-cloud-backup-overview.md
+++ b/content/cloud-backup/rackspace-cloud-backup-overview.md
@@ -12,6 +12,7 @@ product_url: cloud-backup
 ---
 
 **Note:** Cloud Backup works only on Rackspace Cloud Servers.
+**WARNING!** Cloud Backup does **not** follow symlinks.
 
 Rackspace Cloud Backup [product
 page](http://www.rackspace.com/cloud/backup/) is a file-based backup


### PR DESCRIPTION
If a customer believes that CBU will follow symlinks and backup files that are pointed to by the symlinks, they will likely never know that those files are not getting backed up until much too late, when they want to restore one of those files. We need to do due diligence to make sure customers know symlinks are, by design, not followed during CBU backup operations.