### PR TITLE
Customer warning: CBU doesn't follow symlinks.

### DIFF
--- a/content/cloud-backup/best-practices-for-cloud-backup.md
+++ b/content/cloud-backup/best-practices-for-cloud-backup.md
@@ -37,6 +37,8 @@ Knowing the language of backup goes a long way towards helping you make informed
 
 ### Choosing what to backup
 
+**WARNING!** Cloud Backup does **not** follow symlinks. If for instance a symlink points to a file, the symlink itself will be backed up, but not the file it points to. If a symlink points to a folder, the symlink itself will be backed up, but the folder and anything under the folder will not be backed up. If you want files or folders to be backed up, do not attempt to use a symlink to do that.
+
 Our best guidance is not what to backup, but what not to backup:
 
 - Do not back up running databases -- to backup a database, see the topic on [backing up databases](/how-to/rackspace-cloud-backup-backing-up-databases).
@@ -44,9 +46,9 @@ Our best guidance is not what to backup, but what not to backup:
 - Do not back up frequently changing files, such as logs
 - Do not back up root -- to save all data and the server, [make an image of the server](/how-to/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image) instead.
 
-Lastly, do not compress your data before backup, as this defeats the purpose of deduplication. Deduplication saves only the updated information and saves you storage space and money during the backup process.
+Note: Do not compress your data before backup, as this defeats the backup deduplication, which is typically far more efficient than simple file compression. Deduplication stores only the updated data, and saves you storage space and money during the backup process.
 
-The Cloud Backup Agent tries to be helpful, and skips the below types of files automatically. You may, however, manually add them to your backup.
+The Cloud Backup Agent tries to be helpful, and skips the below types of files automatically.
 
 - Memory-only file systems (Linux: /proc, etc. )
 - Cloud Backup agent data directories

--- a/content/cloud-backup/rackspace-cloud-backup-create-a-backup.md
+++ b/content/cloud-backup/rackspace-cloud-backup-create-a-backup.md
@@ -14,6 +14,8 @@ product_url: cloud-backup
 The following steps show how to use the Cloud Backup service to create a
 backup of the data on your cloud server.
 
+**WARNING!** Cloud Backup does **not** follow symlinks.
+
 ### Previous sections
 
 -   [Cloud Backup

--- a/content/cloud-backup/rackspace-cloud-backup-overview.md
+++ b/content/cloud-backup/rackspace-cloud-backup-overview.md
@@ -12,6 +12,7 @@ product_url: cloud-backup
 ---
 
 **Note:** Cloud Backup works only on Rackspace Cloud Servers.
+**WARNING!** Cloud Backup does **not** follow symlinks.
 
 Rackspace Cloud Backup [product
 page](http://www.rackspace.com/cloud/backup/) is a file-based backup


### PR DESCRIPTION
If a customer believes that CBU will follow symlinks and backup files that are pointed to by the symlinks, they will likely never know that those files are not getting backed up until much too late, when they want to restore one of those files. We need to do due diligence to make sure customers know symlinks are, by design, not followed during CBU backup operations.