### PR TITLE
Update available-protocols-when-configuring-a-cloud-load-balancer.md

### DIFF
--- a/content/cloud-load-balancers/available-protocols-when-configuring-a-cloud-load-balancer.md
+++ b/content/cloud-load-balancers/available-protocols-when-configuring-a-cloud-load-balancer.md
@@ -78,7 +78,7 @@ stream of bytes from one program on a computer to another program on
 another computer. Applications that require an ordered and reliable
 delivery of packets use this protocol. See UDP.
 
-**TCP (Client First) **- This protocol is similiar to TCP, but is more
+**TCP (Client First)** - This protocol is similiar to TCP, but is more
 efficient when a client is required to write the data to the server
 before receiving the server's respone.
 *Note: TCP\_CLIENT\_FIRST cannot be placed on a VIP that already


### PR DESCRIPTION
- Fix formatting of `**TCP (Client First)**`.