### PR TITLE
Update managing-users-for-cloud-databases.md

### DIFF
--- a/content/cloud-databases/managing-users-for-cloud-databases.md
+++ b/content/cloud-databases/managing-users-for-cloud-databases.md
@@ -163,7 +163,7 @@ the preceding step:
 Step 4: In MySQL, set up read permissions for DevUser1 by using the
 GRANT statement:
 
-    $ GRANT SELECT on DBStaging1 to 'DevUser1'@'hostname';
+    $ GRANT SELECT on DBStaging1.* to 'DevUser1'@'hostname';
 
 **Note:**  You can reset the root user password by making subsequent
 calls to enable the root user.


### PR DESCRIPTION
The MySQL command to grant permissions to a user was incorrect. Changed due to support feedback:

    $ GRANT SELECT on DBStaging1 to 'DevUser1'@'hostname';
TO
    $ GRANT SELECT on DBStaging1.* to 'DevUser1'@'hostname';