### PR TITLE
remove -0 suffixes from all permalink fields

### DIFF
--- a/content/cloud-dns/create-a-reverse-dns-record.md
+++ b/content/cloud-dns/create-a-reverse-dns-record.md
@@ -1,5 +1,5 @@
 ---
-permalink: create-a-reverse-dns-record-0/
+permalink: create-a-reverse-dns-record/
 node_id: 64
 title: Create a reverse DNS record
 type: article

--- a/content/cloud-files/getting-started-with-cloud-files-and-cdn.md
+++ b/content/cloud-files/getting-started-with-cloud-files-and-cdn.md
@@ -1,5 +1,5 @@
 ---
-permalink: getting-started-with-cloud-files-and-cdn-0/
+permalink: getting-started-with-cloud-files-and-cdn/
 node_id: 5122
 title: Getting started with Cloud Files and CDN
 type: article

--- a/content/cloud-files/protect-your-cloud-files-cdn-bill-from-unexpected-usage.md
+++ b/content/cloud-files/protect-your-cloud-files-cdn-bill-from-unexpected-usage.md
@@ -1,5 +1,5 @@
 ---
-permalink: protect-your-cloud-files-cdn-bill-from-unexpected-usage-0/
+permalink: protect-your-cloud-files-cdn-bill-from-unexpected-usage/
 node_id: 2162
 title: Protect Your Cloud Files CDN Bill from Unexpected Usage
 type: article

--- a/content/cloud-images/creating-an-ubuntu-1310-image-for-the-rackspace-open-cloud.md
+++ b/content/cloud-images/creating-an-ubuntu-1310-image-for-the-rackspace-open-cloud.md
@@ -1,5 +1,5 @@
 ---
-permalink: creating-an-ubuntu-1310-image-for-the-rackspace-open-cloud-0/
+permalink: creating-an-ubuntu-1310-image-for-the-rackspace-open-cloud/
 node_id: 3907
 title: Creating an Ubuntu 13.10 image for the Rackspace open cloud
 type: article

--- a/content/cloud-servers/configuring-basic-security.md
+++ b/content/cloud-servers/configuring-basic-security.md
@@ -1,5 +1,5 @@
 ---
-permalink: configuring-basic-security-0/
+permalink: configuring-basic-security/
 node_id: 1501
 title: Configuring basic security
 type: article

--- a/content/cloud-sites/information-for-mysql-users-mariadb-100.md
+++ b/content/cloud-sites/information-for-mysql-users-mariadb-100.md
@@ -1,5 +1,5 @@
 ---
-permalink: information-for-mysql-users-mariadb-100-0/
+permalink: information-for-mysql-users-mariadb-100/
 node_id: 4729
 title: Information for MySQL Users (MariaDB 10.0)
 type: article

--- a/content/cloud-sites/information-for-new-php-56-apache-version.md
+++ b/content/cloud-sites/information-for-new-php-56-apache-version.md
@@ -1,5 +1,5 @@
 ---
-permalink: information-for-new-php-56-apache-version-0/
+permalink: information-for-new-php-56-apache-version/
 node_id: 4730
 title: 'Information for new PHP 5.6 & Apache version'
 type: article

--- a/content/exchange/adding-microsoft-exchange-mailboxes.md
+++ b/content/exchange/adding-microsoft-exchange-mailboxes.md
@@ -1,5 +1,5 @@
 ---
-permalink: adding-microsoft-exchange-mailboxes-0/
+permalink: adding-microsoft-exchange-mailboxes/
 node_id: 1401
 title: Adding Microsoft Exchange mailboxes
 type: article

--- a/content/rackconnect/rackconnect-release-notes.md
+++ b/content/rackconnect/rackconnect-release-notes.md
@@ -1,5 +1,5 @@
 ---
-permalink: rackconnect-release-notes-0/
+permalink: rackconnect-release-notes/
 node_id: 2160
 title: RackConnect release notes
 type: article

--- a/content/rackspace-email-archiving/set-access-rules-for-archive-end-users.md
+++ b/content/rackspace-email-archiving/set-access-rules-for-archive-end-users.md
@@ -1,5 +1,5 @@
 ---
-permalink: set-access-rules-for-archive-end-users-0/
+permalink: set-access-rules-for-archive-end-users/
 node_id: 4761
 title: Set access rules for archive end users
 type: article

--- a/content/rackspace-email/cloud-office-control-panel-0.md
+++ b/content/rackspace-email/cloud-office-control-panel-0.md
@@ -1,5 +1,5 @@
 ---
-permalink: cloud-office-control-panel-0/
+permalink: cloud-office-control-panel/
 node_id: 3989
 title: Cancel a Cloud Office service
 type: article

--- a/content/rackspace-email/spam-preferences-safe-lists-and-black-list-in-rackspace-email.md
+++ b/content/rackspace-email/spam-preferences-safe-lists-and-black-list-in-rackspace-email.md
@@ -1,5 +1,5 @@
 ---
-permalink: spam-preferences-safe-lists-and-black-list-in-rackspace-email-0/
+permalink: spam-preferences-safe-lists-and-black-list-in-rackspace-email/
 node_id: 1411
 title: 'Spam preferences, safelists, and blacklists in Rackspace Email'
 type: article

--- a/content/rackspace-monitoring/alarm-language-generic-thresholds-made-easy.md
+++ b/content/rackspace-monitoring/alarm-language-generic-thresholds-made-easy.md
@@ -1,5 +1,5 @@
 ---
-permalink: alarm-language-generic-thresholds-made-easy-0/
+permalink: alarm-language-generic-thresholds-made-easy/
 node_id: 1947
 title: Alarm Language - Generic Thresholds Made Easy
 type: article


### PR DESCRIPTION
This removes the trailing `-0` suffixes that were still in the `permalink` field of several articles.