### PR TITLE
Updating the SSL doc to point to the new CA cert

### DIFF
--- a/content/cloud-databases/using-ssl-with-your-cloud-database-instance.md
+++ b/content/cloud-databases/using-ssl-with-your-cloud-database-instance.md
@@ -32,11 +32,19 @@ associated with Cloud Databases.
 **Note:** All database instances created before October 20, 2014, should
 be restarted before accepting SSL connections.
 
-[Download the SSL
+Download the appropriate SSL certificate, based on when the Cloud Databases instance was created
+
+-   For instances created before March 1, 2016 [Download the SSL
 certificate](http://ssl.rackspaceclouddb.com/ca-cert.pem) from the
 following URL:
 
-    http://ssl.rackspaceclouddb.com/ca-cert.pem
+    `http://ssl.rackspaceclouddb.com/ca-cert.pem`
+    
+-   For instances created on or after March 1, 2016 [Download the SSL
+certificate](http://ssl.rackspaceclouddb.com/rackspace-ca-2016.pem) from the
+following URL:
+
+    `http://ssl.rackspaceclouddb.com/rackspace-ca-2016.pem`
 
 Your applications should use the downloaded certificate as the CA
 certificate for SSL connections to your database.


### PR DESCRIPTION
Cloud Databases created after March 1 2016 will require a new CA cert for SSL. This is linking to the new cert.

This one is fairly urgent. Can we push through quickly.