### PR TITLE
Update accessing-the-full-version-of-migrationwiz.md

### DIFF
--- a/content/exchange/accessing-the-full-version-of-migrationwiz.md
+++ b/content/exchange/accessing-the-full-version-of-migrationwiz.md
@@ -40,13 +40,13 @@ consider how that choice can affect migration costs and support procedure.
 #### Cost differences
 
 When migrating to Rackspace Email and Apps, users will receive
-the discounted rate of $4.99 per mailbox only when purchased via
+the discounted rate of $0 per mailbox only when migrating via
 the Private Label Portal at <http://rackspace.selfmigration.com>.  
 
 If purchasing licenses through <http://migrationwiz.com>, those licenses
 will be listed at the retail price of $11.99 per mailbox.  In order
 to take advantage of the discounted rate in the full version of
-MigrationWiz, licenses must first be purchased in the Private Label
+MigrationWiz, migrations must first be initiated in the Private Label
 Portal, then used in the full version.
 
 #### Support differences


### PR DESCRIPTION
Pricing update with the private label from 4.99 to 0 and that they need to start a migration in the private label first to get that pricing in the full version