### PR TITLE
Explain email help tool

### DIFF
--- a/content/skype-for-business/set-up-dns-records-for-cloud-office-email-and-skype-for-business.md
+++ b/content/skype-for-business/set-up-dns-records-for-cloud-office-email-and-skype-for-business.md
@@ -125,6 +125,7 @@ records. Use our help tool for the specific DNS records for your domain.
 After you log in with a mailbox that is enabled for Skype for Business,
 you can find the DNS settings through the [Help
 Tool](https://emailhelp.rackspace.com/) as shown in the following image.
+For the email help tool to work, your MX records must first point to Rackspace.
 
 <img src="{% asset_path skype-for-business/set-up-dns-records-for-cloud-office-email-and-skype-for-business/SkypeforBusinessa.png %}" width="656" height="261" />
 


### PR DESCRIPTION
Due to changes in how the email help tool works (querying MX records to determine the platform a mailbox is on) added line explaining that the tool will only work with MX records pointed correctly.