### PR TITLE
Xentools installer command fix

### DIFF
--- a/content/cloud-monitoring/troubleshooting-the-rackspace-monitoring-agent.md
+++ b/content/cloud-monitoring/troubleshooting-the-rackspace-monitoring-agent.md
@@ -33,8 +33,11 @@ This issue might have one of the following causes:
     agent to work correctly, it must be associated with your server by
     using a Rackspace Monitoring entity. The entity is a representation
     of your server in the monitoring system.
+-   The agent is installed but is not started or is not configured to
+    start automatically during startup.
 -   The monitoring agent is unable to determine the appropriate entity
     because there are duplicate entities associated with your account.
+-   Connectivity issues, firewall problems.
 
 ### Resolution steps
 
@@ -49,11 +52,30 @@ performing the following steps:
 2.  Verify that the **/etc/rackspace-monitoring-agent.cfg** file exists
     and contains a valid agent token.
 3.  Check for errors and status information in the
-    **/var/log/rackspace-monitoring-agent.log** file.
-4.  Verify that port 443 is open (added as a public firewall rule).
-5.  Run the following command to verify that the agent is running:
+    **/var/log/rackspace-monitoring-agent.log** file:
+    
+        $ less /var/log/rackspace-monitoring-agent.log
+
+    This excert from a log file below is demonstrating a connection timeout failure:
+    
+    "Fri Feb 19 10:02:47 PM 2016 **ERR: Connection**: agent-endpoint-lon.monitoring.api.rackspacecloud.com:443 (agent-endpoint-lon.monitoring.api.rackspacecloud.com:443) -> **ETIMEDOUT**"
+
+4.  Run the following command to verify that the agent is running:
 
         $ ps aux | grep rackspace-monitoring-agent
+
+    or
+
+        $ service rackspace-monitoring-agent status
+
+    Attempt to start it if it's not shown as running:
+    
+        $ service rackspace-monitoring-agent start
+
+5.  Ensure that you have firewall rules that allow IPv6 communication or
+    if you have IPv6 disabled, make sure that the firewall is permitting
+    the agent to communicate.
+
 
 ### Windows
 
@@ -68,12 +90,12 @@ performing the following steps:
     contains a valid agent token.
 3.  Check for errors and status information in the
     **C:\\ProgramData\\Rackspace Monitoring\\log.txt** file.
-4.  In the Windows Control Panel, open the settings for Windows Firewall
-    and verify that port 443 is open (added as an inbound
-    firewall rule).
-5.  Verify that the monitoring agent is running by opening the Task
+4.  Verify that the monitoring agent is running by opening the Task
     Manager, clicking the **Services** tab and locating the **Rackspace
     Monitoring** agent service.
+5.  Ensure that you have firewall rules that allow IPv6 communication or
+    if you have IPv6 disabled, make sure that the firewall is permitting
+    the agent to communicate.
 
 ### Check for duplicate entities
 

--- a/content/cloud-servers/first-gen-to-next-gen-cloud-servers-migration-pre-checks.md
+++ b/content/cloud-servers/first-gen-to-next-gen-cloud-servers-migration-pre-checks.md
@@ -103,8 +103,7 @@ If this check fails, the drivers must be reinstalled before your
 migration window. For Linux distributions, run the following script to
 install or update these drivers:
 
-    wget http://437117ba0e2524fdae22-6a87f3acbfcde81a104bb18fbb8cb85f.r47.cf2.rackcdn.com/xen_tools_installer.sh; <br>
-    chmod u+x xen_tools_installer.sh; bash xen_tools_installer.sh; rm -rf xen_tools_installer.sh
+    curl http://437117ba0e2524fdae22-6a87f3acbfcde81a104bb18fbb8cb85f.r47.cf2.rackcdn.com/xen_tools_installer.sh | bash
 
 For Gentoo, Arch, and FreeBSD, or if this installer fails, you must
 install these drivers manually.


### PR DESCRIPTION
This is to fix the PV-driver install command
It has an html <br> tag in it right now (it is a shell command)
The one I propose to be used is in the same format as the one used in the nova-agent installation instructions (just below)