### PR TITLE
fix link to monitoring guide

### DIFF
--- a/content/rackspace-monitoring/mobile-alerts-from-rackspace-monitoring.md
+++ b/content/rackspace-monitoring/mobile-alerts-from-rackspace-monitoring.md
@@ -32,7 +32,7 @@ If you are not yet using Rackspace Monitoring, sign up at no cost on [the Racksp
 
 ## Set up alerts
 
-You configure SMS alerts for your account by adding one or more new notifications via the [raxmon CLI](/how-to/getting-started-with-rackspace-monitoring-cli). You can add SMS alerts to an existing notification plan, or you can create a new one. Be sure to attach the notification plan to one or more alarms. For step-by-step guidance, see the tutorial on setting up notifications and notification plans in the Rackspace Monitoring [_Getting Started Guide_](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#setting-up-notifications).
+You configure SMS alerts for your account by adding one or more new notifications via the [raxmon CLI](/how-to/getting-started-with-rackspace-monitoring-cli). You can add SMS alerts to an existing notification plan, or you can create a new one. Be sure to attach the notification plan to one or more alarms. For step-by-step guidance, see the tutorial on setting up notifications and notification plans in the Rackspace Monitoring [_Getting Started Guide_](https://developer.rackspace.com/docs/rackspace-monitoring/v1/developer-guide/#document-api-operations/notifications-operations).
 
 **Note:** You can create alarms and notifications in any order, but to create a new notification plan, you need to create a notification first.
 


### PR DESCRIPTION
Per Adrian Kiss' email sent to the SDK support group, the link to setting up notifications in the Monitoring dev guide is broken.