### PR TITLE
Add space after audit_date to correct metadata

### DIFF
--- a/content/cloud-servers/rackspace-cloud-essentials-centos-configuring-a-user-in-vsftpd.md
+++ b/content/cloud-servers/rackspace-cloud-essentials-centos-configuring-a-user-in-vsftpd.md
@@ -1,6 +1,6 @@
 ---
 permalink: rackspace-cloud-essentials-centos-configuring-a-user-in-vsftpd/
-audit_date:'2016-06-27'
+audit_date: '2016-06-27'
 title: Rackspace Cloud Essentials - Configure a user in vsftpd for CentOS
 type: article
 created_date: '2011-04-04'


### PR DESCRIPTION
Added space after audit_date to correct metadata which allows page to display correctly.