### PR TITLE
Tweaking alert examples in replication page

### DIFF
--- a/content/cloud-databases/database-replication-with-cloud-databases.md
+++ b/content/cloud-databases/database-replication-with-cloud-databases.md
@@ -92,32 +92,40 @@ After setting up replication, you should periodically monitor your replicas to e
 
 **slave_running:** This is a global status variable and its value can be `ON` or `OFF`. If the value is `ON`, the replica is connected to the source database instance and both the SQL thread and IO thread are running. If the value is `OFF`, you look at `Last_SQL_Errno` and `Last_SQL_Error` for more error information. You can create an alarm to monitor the status of replica with the following criteria.
 
-    if (metric['replication.slave_running'] == "OFF") {
+    if (metric['replication.slave_running'] != "ON") {
 
-      return new AlarmStatus(WARNING, 'Replica is disconnected');
+      return new AlarmStatus(CRITICAL, 'Replica is disconnected');
 
     }
+    return new AlarmStatus(OK, 'Replication slave_running is OK');
 
 **slave\_IO_running:** This variable is a part of the `Show Slave` status and its value can be `Yes`, `No`, or `Connecting`. If the value is `No`, the replica I/O thread is not running and you can look at `Last_IO_Errno` and `Last_IO_Error` for more error information. You can create an alarm to monitor the status of replica IO with the following criteria.
 
-    if (metric['replication.slave_io_running'] == "No") {
+    if (metric['replication.slave_io_running'] != "Yes") {
 
-      return new AlarmStatus(WARNING, 'Replica I/O thread is not running');
+      return new AlarmStatus(CRITICAL, 'Replica I/O thread is not running');
     }
+    return new AlarmStatus(OK, 'Replication slave_io_running is OK');
 
 **slave\_SQL\_running:** This variable is a part of the `Show Slave` status and its value can be `Yes` or `No`. It tells whether the replica's SQL thread has started and is working well. If the value is `No`, you can look at `Last_SQL_Errno` and `Last_SQL_Error` for more error information.
 
-    if (metric['replication.slave_sql_running'] == "No") {
+    if (metric['replication.slave_sql_running'] != "Yes") {
 
-      return new AlarmStatus(WARNING, 'Replica SQL thread is not running');
+      return new AlarmStatus(CRITICAL, 'Replica SQL thread is not running');
 
     }
+    return new AlarmStatus(OK, 'Replication slave_sql_running is OK');
 
 **seconds\_behind\_master:** This variable is a part of the `Show Slave` status and is an integer that measures the time difference in seconds between the slave SQL thread and the slave I/O thread. This field is an indication of how “late” the slave is; When the slave is actively processing updates, this field shows the difference between the current timestamp on the slave and the original timestamp logged on the master for the event currently being processed on the slave. When no event is currently being processed on the slave, this value is 0. In the example below, we send an alarm if the replica is > 30 minutes behind master.
 
     if (metric['replication.seconds_behind_master'] > 1800) {
 
       return new AlarmStatus(CRITICAL, 'Replication Lag of Over 1800 Seconds');
+
+    }
+    if (metric['replication.seconds_behind_master'] > 600) {
+
+      return new AlarmStatus(WARNING, 'Replication Lag of Over 600 Seconds');
 
     }
     return new AlarmStatus(OK, 'Replication seconds_behind_master is OK');


### PR DESCRIPTION
- Adjusted replication and slave thread alerts to be critical rather than Warning
- Changed the logic to be a little more exclusive on the slave thread alerts
- Added a warning threshold on the seconds behind master alert