### PR TITLE
add limitation about boot from volume servers

### DIFF
--- a/content/cloud-servers/about-cloud-server-images.md
+++ b/content/cloud-servers/about-cloud-server-images.md
@@ -46,6 +46,8 @@ images:
 -   If the image process fails more than once and you're sure you haven't
     exceeded the image limits, contact Rackspace Support.
 
+-   **If you are using a boot from volume server, you cannot create an image of it**. You can, however, create snapshots and clones of a boot from volume server.
+
 ### Limitations for Linux servers
 
 -   When an image creation is initiated, the system runs a process that


### PR DESCRIPTION
Fixes #1333 

Adding the inability to create images of boot from volume servers to the list of limitations.