### PR TITLE
Remove internal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ https://support.rackspace.com/how-to/
 
 ### How-to ninja support schedule
 
-For more information see: https://one.rackspace.com/display/devdoc/How-To+support+ninja
 
 - June 27 - July 1: Renée
 - July 4 - 8: Stephanie


### PR DESCRIPTION
Hi y'all,
    
    Can you please scrub your public docs from having private, protected
    URLS listed?
    
     https://github.com/rackerlabs/rackspace-how-to/blob/master/README.md
    
    We should not be linking to internal tools like one.rackspace.com, this
    is an information leak about internal business processes and design.
    This information can possibly be used by a bad actor to map out what's
    behind our firewall perimeter.
    
    thx!
    -te
    
    -- 
    Troy Engel
    GNU/Linux Systems Engineer