### PR TITLE
Remove next-gen from articles

### DIFF
--- a/content/cloud-block-storage/cloud-block-storage-faq.md
+++ b/content/cloud-block-storage/cloud-block-storage-faq.md
@@ -225,7 +225,7 @@ TB in size.
 
 #### How does Cloud Block Storage differ from the local storage available through Cloud Servers?
 
-Cloud Block Storage provides persistent data storage Cloud Servers. Persistent storage can exist independent of your server, even after the server has been deleted. The local storage bundled with Cloud Servers is ephemeral and exists only as long as the Cloud Server exists. When the server is deleted, so is its local storage.
+Cloud Block Storage provides persistent data storage for Cloud Servers. Persistent storage can exist independent of your server, even after the server has been deleted. The local storage bundled with Cloud Servers is ephemeral and exists only as long as the Cloud Server exists. When the server is deleted, so is its local storage.
 
 We recommend that you [unmount and detach Cloud Block
 Storage](/how-to/detach-and-delete-cloud-block-storage-volumes)

--- a/content/cloud-block-storage/cloud-block-storage-faq.md
+++ b/content/cloud-block-storage/cloud-block-storage-faq.md
@@ -5,7 +5,7 @@ title: Cloud Block Storage FAQ
 type: article
 created_date: '2015-12-10'
 created_by: Rackspace Support
-last_modified_date: '2016-09-12'
+last_modified_date: '2016-09-13'
 last_modified_by: Kyle Laffoon
 product: Cloud Block Storage
 product_url: cloud-block-storage
@@ -230,11 +230,7 @@ TB in size.
 
 #### How does Cloud Block Storage differ from the local storage available through Cloud Servers?
 
-Cloud Block Storage provides persistent data storage for next generation
-Cloud Servers. Persistent storage can exist independent of your server,
-even after the server has been deleted. The local storage bundled with
-Cloud Servers is ephemeral and exists only as long as the Cloud Server
-exists. When the server is deleted, so is its local storage.
+Cloud Block Storage provides persistent data storage Cloud Servers. Persistent storage can exist independent of your server, even after the server has been deleted. The local storage bundled with Cloud Servers is ephemeral and exists only as long as the Cloud Server exists. When the server is deleted, so is its local storage.
 
 We recommend that you [unmount and detach Cloud Block
 Storage](/how-to/detach-and-delete-cloud-block-storage-volumes)

--- a/content/cloud-block-storage/index.md
+++ b/content/cloud-block-storage/index.md
@@ -3,14 +3,14 @@ title: Cloud Block Storage
 type: product
 created_date: '2016-01-17'
 created_by: Rackspace Support
-last_modified_date: '2016-01-22'
-last_modified_by: Rackspace Support
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 permalink: /cloud-block-storage/
 product: Cloud Block Storage
 product_url: cloud-block-storage
 ---
 
-<p class="lead" markdown="1">Cloud Block Storage lets you extend the storage capacity of your Rackspace Next Generation Cloud Servers&trade; and OnMetal&trade; Cloud Servers without needing to create a bigger server.</p>
+<p class="lead" markdown="1">Cloud Block Storage lets you extend the storage capacity of your Rackspace Cloud Servers&trade; and OnMetal&trade; Cloud Servers without needing to create a bigger server.</p>
 
 <hr />
 

--- a/content/cloud-block-storage/prepare-your-cloud-block-storage-volume.md
+++ b/content/cloud-block-storage/prepare-your-cloud-block-storage-volume.md
@@ -248,7 +248,7 @@ Now the volume persists on the server after server restarts.
 ### Prepare your volume for use with a Windows server
 
 **Note**: In the examples in the procedure, a 100 GB volume is added to
-a Windows Server 2012 server. The steps are similar for all Windows cloud servers.
+a Windows Server 2012 server. The steps are similar for all next-generation Windows cloud servers.
 
 #### Remotely connect to your Server.
 

--- a/content/cloud-block-storage/prepare-your-cloud-block-storage-volume.md
+++ b/content/cloud-block-storage/prepare-your-cloud-block-storage-volume.md
@@ -248,7 +248,7 @@ Now the volume persists on the server after server restarts.
 ### Prepare your volume for use with a Windows server
 
 **Note**: In the examples in the procedure, a 100 GB volume is added to
-a Windows Server 2012 server. The steps are similar for all next-generation Windows cloud servers.
+a Windows Server 2012 server. The steps are similar for all Windows cloud servers.
 
 #### Remotely connect to your Server.
 

--- a/content/cloud-block-storage/prepare-your-cloud-block-storage-volume.md
+++ b/content/cloud-block-storage/prepare-your-cloud-block-storage-volume.md
@@ -5,8 +5,8 @@ title: Prepare your Cloud Block Storage volume
 type: article
 created_date: '2012-10-21'
 created_by: David Hendler
-last_modified_date: '2016-06-06'
-last_modified_by: Nate Archer
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: Cloud Block Storage
 product_url: cloud-block-storage
 ---
@@ -248,8 +248,7 @@ Now the volume persists on the server after server restarts.
 ### Prepare your volume for use with a Windows server
 
 **Note**: In the examples in the procedure, a 100 GB volume is added to
-a Windows Server 2012 server. The steps are similar for all
-next-generation Windows cloud servers.
+a Windows Server 2012 server. The steps are similar for all Windows cloud servers.
 
 #### Remotely connect to your Server.
 

--- a/content/cloud-servers/cloud-servers-faq.md
+++ b/content/cloud-servers/cloud-servers-faq.md
@@ -5,7 +5,7 @@ title: Cloud Servers FAQ
 type: article
 created_date: '2015-12-01'
 created_by: Rackspace Support
-last_modified_date: '2016-09-12'
+last_modified_date: '2016-09-13'
 last_modified_by: Kyle Laffoon
 product: Cloud Servers
 product_url: cloud-servers
@@ -375,8 +375,7 @@ size of the customers' Cloud Servers, and the type of operating system.
 
 **Note**: [General Purpose Cloud Servers](/how-to/new-features-in-general-purpose-and-work-optimized-cloud-servers)
 have specific virtual CPU allocations, as detailed on the [Cloud Servers pricing page](http://www.rackspace.com/cloud/servers/pricing/). The
-following information on CPU scheduling applies only to next-generation
-standard (for example, not General Purpose) Cloud Servers.
+following information on CPU scheduling applies only to standard (for example, not General Purpose) Cloud Servers.
 
 For Windows images, each Cloud Server is assigned a number of virtual
 cores based on the size of the Cloud Server. The Standard 1 GB Cloud

--- a/content/cloud-servers/cloud-servers-faq.md
+++ b/content/cloud-servers/cloud-servers-faq.md
@@ -375,7 +375,7 @@ size of the customers' Cloud Servers, and the type of operating system.
 
 **Note**: [General Purpose Cloud Servers](/how-to/new-features-in-general-purpose-and-work-optimized-cloud-servers)
 have specific virtual CPU allocations, as detailed on the [Cloud Servers pricing page](http://www.rackspace.com/cloud/servers/pricing/). The
-following information on CPU scheduling applies only to standard (for example, not General Purpose) Cloud Servers.
+following information on CPU scheduling applies to standard Cloud Servers only.
 
 For Windows images, each Cloud Server is assigned a number of virtual
 cores based on the size of the Cloud Server. The Standard 1 GB Cloud

--- a/content/cloud-servers/permissions-matrix-for-next-generation-cloud-servers.md
+++ b/content/cloud-servers/permissions-matrix-for-next-generation-cloud-servers.md
@@ -1,18 +1,18 @@
 ---
 permalink: permissions-matrix-for-next-generation-cloud-servers/
 audit_date:
-title: Permissions Matrix for Next Generation Cloud Servers
+title: Permissions Matrix for Cloud Servers
 type: article
 created_date: '2013-04-10'
 created_by: Renee Rendon
-last_modified_date: '2016-04-29'
-last_modified_by: Renee Rendon
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: Cloud Servers
 product_url: cloud-servers
 ---
 
 The following permissions matrix displays specific permissions for the
-roles in Next Gen Cloud Servers. The matrix displays the method names,
+roles in Cloud Servers. The matrix displays the method names,
 their corresponding RESTful API commands, and the roles that are
 supported.
 
@@ -20,7 +20,7 @@ supported.
 
 [Related Rackspace How-To Articles](/how-to/)
 
-### Next Generation Cloud Servers Terminology
+### Cloud Servers Terminology
 
 #### Flavor
 

--- a/content/cloud-servers/speed-up-rsync-when-migrating-a-linux-server-from-the-command-line.md
+++ b/content/cloud-servers/speed-up-rsync-when-migrating-a-linux-server-from-the-command-line.md
@@ -5,7 +5,6 @@ title: Speed up rsync when migrating a Linux server from the command line
 type: article
 created_date: '2011-06-23'
 created_by: Rackspace Support
-<<<<<<< HEAD
 last_modified_date: '2016-09-13'
 =======
 last_modified_date: '2016-09-12'
@@ -136,7 +135,6 @@ This unpredictability is particularly true for the final directory on Linux file
 
 The second uncertainty is that the final phase of a migration includes a rescue mode (downtime) component during which any files updated since the live rsync first phase began, are copied again. The length of the downtime depends on the size and number of updated files. Again, the rsync process cannot tell in advance how many updates applications like MySQL are writing to data files so it’s hard to predict how long this final 'rescue-mode rsync' copy will take.
 
-<<<<<<< HEAD
 The above applies to a typical manual migration process, which is similar to resizing a server on our first-generation Rackspace Cloud. Our Cloud changes the resize process to bring the server down for a single rsync, increasing downtime but also increasing the reliability of the sync.
 
 =======

--- a/content/cloud-servers/speed-up-rsync-when-migrating-a-linux-server-from-the-command-line.md
+++ b/content/cloud-servers/speed-up-rsync-when-migrating-a-linux-server-from-the-command-line.md
@@ -8,7 +8,6 @@ created_by: Rackspace Support
 last_modified_date: '2016-09-13'
 =======
 last_modified_date: '2016-09-12'
->>>>>>> master
 last_modified_by: Kyle Laffoon
 product: Cloud Servers
 product_url: cloud-servers
@@ -138,7 +137,6 @@ The second uncertainty is that the final phase of a migration includes a rescue 
 The above applies to a typical manual migration process, which is similar to resizing a server on our first-generation Rackspace Cloud. Our Cloud changes the resize process to bring the server down for a single rsync, increasing downtime but also increasing the reliability of the sync.
 
 =======
->>>>>>> master
 ### Summary
 
 If you know how your applications are using disk space and writing to files you may be able to judge how much time a migration will take longer than you would like and make preparations accordingly. At the very least, you should be able to use your new-found migration knowledge to better schedule migration to fit your timing requirements.

--- a/content/cloud-servers/speed-up-rsync-when-migrating-a-linux-server-from-the-command-line.md
+++ b/content/cloud-servers/speed-up-rsync-when-migrating-a-linux-server-from-the-command-line.md
@@ -136,7 +136,6 @@ The second uncertainty is that the final phase of a migration includes a rescue 
 
 The above applies to a typical manual migration process, which is similar to resizing a server on our first-generation Rackspace Cloud. Our Cloud changes the resize process to bring the server down for a single rsync, increasing downtime but also increasing the reliability of the sync.
 
-=======
 ### Summary
 
 If you know how your applications are using disk space and writing to files you may be able to judge how much time a migration will take longer than you would like and make preparations accordingly. At the very least, you should be able to use your new-found migration knowledge to better schedule migration to fit your timing requirements.

--- a/content/cloud-servers/speed-up-rsync-when-migrating-a-linux-server-from-the-command-line.md
+++ b/content/cloud-servers/speed-up-rsync-when-migrating-a-linux-server-from-the-command-line.md
@@ -5,8 +5,8 @@ title: Speed up rsync when migrating a Linux server from the command line
 type: article
 created_date: '2011-06-23'
 created_by: Rackspace Support
-last_modified_date: '2014-09-04'
-last_modified_by: Ross Diaz
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: Cloud Servers
 product_url: cloud-servers
 ---
@@ -132,7 +132,7 @@ This unpredictability is particularly true for the final directory on Linux file
 
 The second uncertainty is that the final phase of a migration includes a rescue mode (downtime) component during which any files updated since the live rsync first phase began, are copied again. The length of the downtime depends on the size and number of updated files. Again, the rsync process cannot tell in advance how many updates applications like MySQL are writing to data files so it’s hard to predict how long this final 'rescue-mode rsync' copy will take.
 
-The above applies to a typical manual migration process, which is similar to resizing a server on our first-generation Rackspace Cloud. Our next-generation Cloud changes the resize process to bring the server down for a single rsync, increasing downtime but also increasing the reliability of the sync.
+The above applies to a typical manual migration process, which is similar to resizing a server on our first-generation Rackspace Cloud. Our Cloud changes the resize process to bring the server down for a single rsync, increasing downtime but also increasing the reliability of the sync.
 
 ### Summary
 

--- a/content/managed-operations/windows-server-2012-r2-with-managed-operations-support.md
+++ b/content/managed-operations/windows-server-2012-r2-with-managed-operations-support.md
@@ -122,8 +122,9 @@ unlimited virtualization use rights. Customers who would have had to
 chose among Web, Standard and Enterprise editions can now simply select
 Standard edition.
 
-**Note**: Cloud customers will have access to Windows Server 2012 R2
-images through the Cloud Servers API and Control Panel.
+**Notes**:
 
-**Note**: MyRack is used by customers with dedicated servers and is the
-interface for RackConnect.
+- Cloud customers will have access to Windows Server 2012 R2 images through the Cloud Servers API
+  and Control Panel.
+
+- MyRack is used by customers with dedicated servers and is the interface for RackConnect.

--- a/content/managed-operations/windows-server-2012-r2-with-managed-operations-support.md
+++ b/content/managed-operations/windows-server-2012-r2-with-managed-operations-support.md
@@ -5,8 +5,8 @@ title: Windows Server 2012 R2 with Managed Operations support
 type: article
 created_date: '2012-10-09'
 created_by: Rae D. Cabello
-last_modified_date: '2016-01-21'
-last_modified_by: Kelly Holcomb
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: Managed Operations
 product_url: managed-operations
 ---
@@ -123,8 +123,7 @@ chose among Web, Standard and Enterprise editions can now simply select
 Standard edition.
 
 **Note**: Cloud customers will have access to Windows Server 2012 R2
-images through the next generation Cloud Servers API and Control Panel.
+images through the Cloud Servers API and Control Panel.
 
 **Note**: MyRack is used by customers with dedicated servers and is the
 interface for RackConnect.
-

--- a/content/rackconnect/features-introduced-in-rackconnect-v20.md
+++ b/content/rackconnect/features-introduced-in-rackconnect-v20.md
@@ -5,8 +5,8 @@ title: Features introduced in RackConnect v2.0
 type: article
 created_date: '2012-08-21'
 created_by: Juan Perez
-last_modified_date: '2016-01-21'
-last_modified_by: Kelly Holcomb
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: RackConnect
 product_url: rackconnect
 ---
@@ -19,7 +19,7 @@ v2.0](/how-to/introducing-rackconnect-v20)
 The 2.0 version of RackConnect added the following automation and
 security features:
 
--   **Support for next generation Rackspace Cloud Servers**, powered by
+-   **Support for Rackspace Cloud Servers**, powered by    
     OpenStack<sup>&reg;</sup>
 
 -   **RackConnect API**, which gives you a way to programmatically

--- a/content/rackconnect/how-to-programmatically-determine-the-rackconnect-v20-automation-status-of-your-cloud.md
+++ b/content/rackconnect/how-to-programmatically-determine-the-rackconnect-v20-automation-status-of-your-cloud.md
@@ -5,7 +5,7 @@ title: Programmatically determine the RackConnect v2.0 Automation status of your
 type: article
 created_date: '2012-10-02'
 created_by: Juan Perez
-last_modified_date: '2016-09-12'
+last_modified_date: '2016-09-13'
 last_modified_by: Kyle Laffoon
 product: RackConnect
 product_url: rackconnect
@@ -59,7 +59,7 @@ RackConnect:
 cloud server in a region that does not match your RackConnect
 configuration region.
 
-#### Obtaining the metadata information via the Next Generation Cloud Servers API (examples)
+#### Obtaining the metadata information via the Cloud Servers API (examples)
 
 **Authenticate and obtain an authentication token**
 

--- a/content/rackconnect/rackconnect-10-post-upgrade-faq.md
+++ b/content/rackconnect/rackconnect-10-post-upgrade-faq.md
@@ -5,8 +5,8 @@ title: RackConnect 1.0 post-upgrade FAQ
 type: article
 created_date: '2012-08-23'
 created_by: Juan Perez
-last_modified_date: '2016-01-05'
-last_modified_by: Rose Contreras
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: RackConnect
 product_url: rackconnect
 ---
@@ -35,7 +35,7 @@ originally configured with RackConnect v1.0, you can disregard this article.
     means that changes in your cloud environment are picked up by
     RackConnect much faster, providing improved performance.
 
--   This upgrade enables you to use next generation cloud servers.
+-   This upgrade enables you to use cloud servers.
 
 #### What's the difference between this upgrade and the full RackConnect v2.0 feature set?
 

--- a/content/rackconnect/rackconnect-faq.md
+++ b/content/rackconnect/rackconnect-faq.md
@@ -5,7 +5,7 @@ title: RackConnect FAQ
 type: article
 created_date: '2014-09-26'
 created_by: Juan Perez
-last_modified_date: '2016-09-12'
+last_modified_date: '2016-09-13'
 last_modified_by: Kyle Laffoon
 product: RackConnect
 product_url: rackconnect
@@ -32,10 +32,7 @@ Not yet, but we are working on a migration path. Initially, we plan to
 offer you the ability to associate a *new* cloud account with your
 existing RackConnect v2.0 configuration, which will enable you to
 experience RackConnect v3.0 without deactivating your existing
-RackConnect v2.0 environment. Note that only *next generation cloud
-servers* will be compatible with the migration process to RackConnect
-v3.0. We will provide more details about this process as they become
-available.
+RackConnect v2.0 environment. Note that only *cloud servers* will be compatible with the migration process to RackConnect v3.0. We will provide more details about this process as they become available.
 
 #### Can I use a Brocade ADX 1000 as my RackConnect v3.0 edge device?
 
@@ -345,7 +342,7 @@ the snapshot must have a clean SSH configuration that permits root
 login, with port 22 open in iptables, and accepts password
 authentication.
 
-#### How do I retrieve the public IP address for a next generation cloud server that has been recently provisioned?
+#### How do I retrieve the public IP address for a cloud server that has been recently provisioned?
 
 You can view the public IP address of your RackConnect cloud server in
 the following places:
@@ -360,21 +357,20 @@ the following places:
     the API to retrieve server information, see the [Getting server details](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#getting-server-details)
     section in the *Cloud Servers v2 Developer Guide*.
 
-#### Can I use next generation cloud server images to create cloud servers in different regions?
+#### Can I use cloud server images to create cloud servers in different regions?
 
-It is not currently possible to use next generation images (snapshots)
+It is not currently possible to use cloud server images (snapshots)
 created in one region to spin up cloud servers in a different region. We
 expect this functionality to be available in late 2013.
 
-Due to the limitation above, if you would like to use next generation cloud
-server images with RackConnect, follow this process:
+Due to the limitation above, if you would like to use cloud server images with RackConnect, follow this process:
 
-1.  Create a next generation cloud server in the same region as your RackConnect configuration.
+1.  Create a cloud server in the same region as your RackConnect configuration.
 2.  After the cloud server is deployed and configured as you would like, you can create an image (snapshot) of it.
-3.  You can now create new next generation cloud servers from this image, as long as they are created in the same region in which your
+3.  You can now create new cloud servers from this image, as long as they are created in the same region in which your
     RackConnect configuration is located.
 
-**Note**: If you have existing next generation images that were created
+**Note**: If you have existing cloud server images that were created
 in a different region than where your RackConnect configuration is
 located, then it will not be possible to use them with RackConnect until
 the first half of 2014 (expected time frame).

--- a/content/rackconnect/rackconnect-power-users-guide.md
+++ b/content/rackconnect/rackconnect-power-users-guide.md
@@ -5,8 +5,8 @@ title: RackConnect Power Users Guide
 type: article
 created_date: '2012-11-09'
 created_by: Jonathan Hogue
-last_modified_date: '2016-01-06'
-last_modified_by: Rose Contreras
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: RackConnect
 product_url: rackconnect
 ---
@@ -66,10 +66,7 @@ accessible from your dedicated environment.
 
 ### How to decrease build times
 
-Use manual disk mode. The Rackspace Next Generation Cloud Servers API
-has an extension called `diskConfig` that enables you to control how the
-cloud server disk is partitioned when servers are created, rebuilt, or
-resized. There are two modes: manual and auto.
+Use manual disk mode. The Rackspace Cloud Servers API has an extension called `diskConfig` that enables you to control how the cloud server disk is partitioned when servers are created, rebuilt, or resized. There are two modes: manual and auto.
 
 -   Auto: The server is built with a single partition the size of the
     target disk. The file system is automatically adjusted to fit the

--- a/content/rackconnect/rackconnect-release-notes.md
+++ b/content/rackconnect/rackconnect-release-notes.md
@@ -83,7 +83,7 @@ RackConnect.
 
 ### August 1, 2012
 
--   Added support for next generation Cloud Servers.
+-   Added support for Cloud Servers.
 
 ### July 02, 2012
 
@@ -106,9 +106,7 @@ RackConnect automation.
 is disabled, leading to an instance that does not have proper
 connectivity and thus fails RackConnect automation.
 
-**Affects:** Snapshots created from next generation Managed Operations
-Windows Servers where the Cloud Server from which the image is based was
-spun up before 9/6/12.
+**Affects:** Snapshots created from Managed Operations Windows Servers where the Cloud Server from which the image is based was spun up before 9/6/12.
 
 **Workaround:** Re-enable IPv6 on the base image before creating snapshots.
 See [http://support.microsoft.com/kb/929852](http://support.microsoft.com/kb/929852) for instructions.

--- a/content/rackconnect/rackconnect-v30-cloud-server-image-compatibility.md
+++ b/content/rackconnect/rackconnect-v30-cloud-server-image-compatibility.md
@@ -21,7 +21,7 @@ of images available for your cloud account by using the
 API](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#document-getting-started/create-server/list-images),
 or when you build a new cloud server in the [Cloud Control
 Panel](https://mycloud.rackspace.com/). RackConnect v3.0 is also
-compatible with all Cloud Servers flavors, including Standard and General Purpose flavors, as well as I/O, Compute, and Memory optimized flavors.
+compatible with the following Cloud Servers flavor types: Standard, General Purpose, and I/O, Compute, and Memory optimized.
 
 This enhanced image compatibility is possible because
 RackConnect v3.0 leverages the same underlying technology as Cloud

--- a/content/rackconnect/rackconnect-v30-cloud-server-image-compatibility.md
+++ b/content/rackconnect/rackconnect-v30-cloud-server-image-compatibility.md
@@ -5,8 +5,8 @@ title: RackConnect v3.0 Cloud Servers image compatibility
 type: article
 created_date: '2014-09-19'
 created_by: Juan Perez
-last_modified_date: '2014-12-17'
-last_modified_by: Jered Heeschen
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: RackConnect
 product_url: rackconnect
 ---
@@ -21,9 +21,7 @@ of images available for your cloud account by using the
 API](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#document-getting-started/create-server/list-images),
 or when you build a new cloud server in the [Cloud Control
 Panel](https://mycloud.rackspace.com/). RackConnect v3.0 is also
-compatible with all next generation Cloud Servers flavors, including
-Standard and General Purpose flavors, as well as I/O, Compute, and
-Memory optimized flavors.
+compatible with all Cloud Servers flavors, including Standard and General Purpose flavors, as well as I/O, Compute, and Memory optimized flavors.
 
 This enhanced image compatibility is possible because
 RackConnect v3.0 leverages the same underlying technology as Cloud

--- a/content/rackconnect/rackconnect-v30-compatibility.md
+++ b/content/rackconnect/rackconnect-v30-compatibility.md
@@ -5,8 +5,8 @@ title: RackConnect v3.0 compatibility
 type: article
 created_date: '2014-09-08'
 created_by: Juan Perez
-last_modified_date: '2016-01-21'
-last_modified_by: Kelly Holcomb
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: RackConnect
 product_url: rackconnect
 ---
@@ -25,7 +25,7 @@ Product | Requirements | Details | Product information
 --- | --- | --- | ---
 Auto Scale | None | Auto Scale is an API-based tool that automatically scales resources in response to an increase or decrease in overall workload based on user-defined thresholds. Auto Scale enables you to automatically scale your RackConnect cloud servers resources to adjust to customer demand. <br /><br /> See the [Cloud Bursting with RackConnectV3](https://developer.rackspace.com/docs/autoscale/v1/developer-guide/#cloud-bursting) section of the *Rackspace Auto Scale Developer Guide* for details about using Auto Scale with RackConnect v3.0. | [Auto Scale Getting Started Guide](https://developer.rackspace.com/docs/autoscale/v1/developer-guide/#getting-started)<br /><br /> [Auto Scale Developer Guide](https://developer.rackspace.com/docs/autoscale/v1/developer-guide/#document-developer-guide)<br /><br /> [Cloud Bursting with RackConnectV3](https://developer.rackspace.com/docs/autoscale/v1/developer-guide/#cloud-bursting)
 Cloud Backup | ServiceNet | Cloud Backup is a file-based backup application that enables you to choose which files and folders to back up from your cloud servers. You can choose to restore your whole system with all of its folders and files, or individual files or folders from a given date, to restore to an entirely different server. | [Getting Started with Rackspace Cloud Backup](/how-to/cloud-backup)
-Cloud Block Storage | None | Cloud Block Storage is a block-level storage solution that enables you to expand the storage capacity of your Rackspace Next Generation Cloud Servers. | [Getting Started with Cloud Block Storage](/how-to/cloud-block-storage)
+Cloud Block Storage | None | Cloud Block Storage is a block-level storage solution that enables you to expand the storage capacity of your Rackspace  Cloud Servers. | [Getting Started with Cloud Block Storage](/how-to/cloud-block-storage)
 Cloud Databases | ServiceNet | Cloud Databases is a stand-alone, API-based relational database service built on the OpenStack&reg; cloud that enables you to easily provision and manage multiple MySQL database instances. Instances are provisioned in a single-tenant, container-based environment per account. <br /><br /> RackConnect v3.0 is <strong>compatible</strong> with MySQL Cloud Databases instances. <br /><br /> **Note:** Cloud Databases is compatible with cloud servers only and cannot be used directly with dedicated servers. | [Getting Started with Cloud Databases](/how-to/cloud-databases)
 Cloud Files | ServiceNet | Cloud Files provides an easy-to-use online storage for files and media that can be delivered globally at fast speeds over the Akamai content delivery network (CDN). | [Getting Started with Cloud Files](/how-to/cloud-files)
 Cloud Monitoring | Provisioned public IP address | Cloud Monitoring provides you with timely and accurate information about how your resources are performing. You can quickly create multiple monitors that use predefined checks such as PING, HTTPS, and SMTP to track your cloud resources and receive instant notification when a resource needs your attention. | [Getting Started with Cloud Monitoring](/how-to/cloud-monitoring)

--- a/content/rackconnect/the-rackconnect-v20-api.md
+++ b/content/rackconnect/the-rackconnect-v20-api.md
@@ -5,8 +5,8 @@ title: RackConnect v2.0 API
 type: article
 created_date: '2012-08-21'
 created_by: Juan Perez
-last_modified_date: '2016-01-06'
-last_modified_by: Catherine Richardson
+last_modified_date: '2016-09-13'
+last_modified_by: Kyle Laffoon
 product: RackConnect
 product_url: rackconnect
 ---
@@ -40,12 +40,7 @@ You can use the RackConnect API to access the following information:
 
 **Note:** In addition to using the RackConnect API, you can now use the
 Cloud Servers API to query the RackConnect automation status of your
-next-generation cloud servers. The benefit of using the Cloud Servers
-API is that you do not need to perform the query from the cloud
-server for which you want the status. The limitations of this method are that
-only the RackConnect automation status is available, and this method is
-compatible only with next-generation cloud servers. If you are
-interested in this method, see [Programmatically determine the RackConnect v2.0 automation status of your cloud servers](/how-to/how-to-programmatically-determine-the-rackconnect-v20-automation-status-of-your-cloud).
+cloud servers. The benefit of using the Cloud Servers API is that you do not need to perform the query from the cloud server for which you want the status. The limitations of this method are that only the RackConnect automation status is available, and this method is compatible only with cloud servers. If you are interested in this method, see [Programmatically determine the RackConnect v2.0 automation status of your cloud servers](/how-to/how-to-programmatically-determine-the-rackconnect-v20-automation-status-of-your-cloud).
 
 ### API basics
 


### PR DESCRIPTION
This round removes "next-generation" with hyphens.