### PR TITLE
add audit date for completed full audit

### DIFF
--- a/content/exchange/manually-configure-android-devices-for-email-hosted-on-exchange-2013.md
+++ b/content/exchange/manually-configure-android-devices-for-email-hosted-on-exchange-2013.md
@@ -1,6 +1,6 @@
 ---
 permalink: manually-configure-android-devices-for-email-hosted-on-exchange-2013/
-audit_date:
+audit_date: '2016-09-12'
 title: Manually configure Android devices for email hosted on Exchange 2013
 type: article
 created_date: '2014-01-31'


### PR DESCRIPTION
Forgot to add the `audit_date` after finishing the full audit for "Manually configure Android devices for email hosted on Exchange 2013"