### PR TITLE
Update detach-and-delete-cloud-block-storage-volumes.md

### DIFF
--- a/content/cloud-block-storage/detach-and-delete-cloud-block-storage-volumes.md
+++ b/content/cloud-block-storage/detach-and-delete-cloud-block-storage-volumes.md
@@ -40,7 +40,7 @@ prevent errors.
 
   At your server, use the **df -h** command to see how it is mounted.
 
-    <img src="{% asset_path cloud-block-storage/detach-and-delete-cloud-block-storage-volumes/mount_point.png %}" width="571" height="122" />
+   <img src="{% asset_path cloud-block-storage/detach-and-delete-cloud-block-storage-volumes/mount_point.png %}" width="571" height="122" />
 
 2. Use the value under **Mounted On** in the unmount command.
 


### PR DESCRIPTION
The "Unmount volume from a Linux server" section on the support.rackspace.com was showing steps 1,1,2 and the image for step 1 was showing the html code instead of the mount_point.png.
This fork shows numbering correctly as 1,2,3, and removing leading spaces from the html code for the mount_point.png may have corrected the display problem.