### PR TITLE
add permalink to metadata

### DIFF
--- a/content/exchange/public-folder-permissions-for-exchange.md
+++ b/content/exchange/public-folder-permissions-for-exchange.md
@@ -1,4 +1,5 @@
 ---
+permalink: public-folder-permissions-for-exchange/
 audit_date:
 title: Public folder permissions for Exchange
 type: article


### PR DESCRIPTION
Found another article missing the `permalink` field in the metadata