### PR TITLE
Full audit for Troubleshooting Alerts

### DIFF
--- a/content/rackspace-monitoring/troubleshooting-alarms.md
+++ b/content/rackspace-monitoring/troubleshooting-alarms.md
@@ -1,25 +1,24 @@
 ---
-permalink: troubleshooting-alarms/
+permalink: troubleshooting-alerts/
 audit_date:
-title: Troubleshooting Alarms
+title: Troubleshooting alerts
 type: article
 created_date: '2012-09-04'
 created_by: Susan Million
-last_modified_date: '2016-01-22'
-last_modified_by: Constanze Kratel
+last_modified_date: '2016-10-28'
+last_modified_by: Nate Archer
 product: Rackspace Monitoring
 product_url: rackspace-monitoring
 ---
 
 When a monitoring check reaches or passes a specific threshold or value,
-an alarm is triggered and you'll receive a Warning or Critical email
+an alert is triggered and you'll receive a Warning or Critical email
 notification for the monitored resource. This article describes some
 simple troubleshooting steps that can help you diagnose the problem.
 
 ### Ping checks
 
-
-Ping checks typically monitor a server. If your ping check alarm is
+Ping checks typically monitor a server. If your ping check alert is
 triggered, you should immediately try to contact your server using the
 **ping** command.
 
@@ -28,12 +27,9 @@ Command Prompt, or a Linux shell:
 
     ping <target_hostname or ip_address>
 
-The following ehow article provides some helpful information about how
-to read the results of a ping test: [How to Read Ping Test
-Results](http://www.ehow.com/how_8241153_read-ping-test-results.html).
+If a host returns a result of `O packets received`, you might be experiencing network connection issues. Use the networking tool `traceroute` to diagnose any network issues. For more information on using ping and traceroute for network troubleshooting, see [Common network troubleshooting tools](how-to/common-network-troubleshooting-tools/).
 
-###HTTP checks
-
+### HTTP checks
 
 The HTTP check is used to check websites. If you receive a notification
 from an HTTP check, try the following preliminary troubleshooting steps:
@@ -75,8 +71,7 @@ The output should look something like this:
 
 ### TCP checks
 
-
-TCP checks monitor ports. If an alarm is triggered for a TCP check, try
+TCP checks monitor ports. If an alert is triggered for a TCP check, try
 to use Telnetto communicate with the target or scan your target for the
 open port.
 
@@ -97,11 +92,11 @@ To exit telnet, type `Ctrl  \]`, press the **Enter** key, and then type `quit`.
 
 ### Contact Rackspace Technical Support
 
-
 If you're unable to solve the problem using the steps outlined in this
-article, contact Rackspace Technical Support by using the Cloud Control
-Panel. Your options for contacting Rackspace are as follows:
+article, review the information in the following documents:
 
--   Open a Support Ticket
--   Use Live Chat
--   Call the toll free number for your area
+- [Rackspace Monitoring API status code reference](https://developer.rackspace.com/docs/rackspace-monitoring/v1/tech-ref-info/check-type-reference/#check-status-codes)
+
+- [Checks and Alarms](how-to/rackspace-monitoring-checks-and-alarms/)
+
+If you need more assistance, contact [Rackspace Support](https://www.rackspace.com/support).

--- a/content/rackspace-monitoring/troubleshooting-alarms.md
+++ b/content/rackspace-monitoring/troubleshooting-alarms.md
@@ -1,6 +1,6 @@
 ---
 permalink: troubleshooting-alerts/
-audit_date:
+audit_date: '2016-11-01'
 title: Troubleshooting alerts
 type: article
 created_date: '2012-09-04'
@@ -12,53 +12,52 @@ product_url: rackspace-monitoring
 ---
 
 When a monitoring check reaches or passes a specific threshold or value,
-an alert is triggered and you'll receive a Warning or Critical email
+an alert is triggered and you receive a Warning or Critical email
 notification for the monitored resource. This article describes some
 simple troubleshooting steps that can help you diagnose the problem.
 
 ### Ping checks
 
-Ping checks typically monitor a server. If your ping check alert is
-triggered, you should immediately try to contact your server using the
+Ping checks typically monitor a server. If your ping check triggers an alert immediately try to contact your server by using the
 **ping** command.
 
 Issue the following command from an OS X Terminal window, Windows
 Command Prompt, or a Linux shell:
 
-    ping <target_hostname or ip_address>
+    ping <targetHostnameorIpaddress>
 
-If a host returns a result of `O packets received`, you might be experiencing network connection issues. Use the networking tool `traceroute` to diagnose any network issues. For more information on using ping and traceroute for network troubleshooting, see [Common network troubleshooting tools](how-to/common-network-troubleshooting-tools/).
+If the host returns a result of `O packets received`, you might be experiencing network connection issues. Use the `traceroute` networking to diagnose any network issues. For more information about using ping and traceroute for network troubleshooting, see [Common network troubleshooting tools](/how-to/common-network-troubleshooting-tools/).
 
 ### HTTP checks
 
-The HTTP check is used to check websites. If you receive a notification
+HTTPs check are used to check websites. If you receive a notification
 from an HTTP check, try the following preliminary troubleshooting steps:
 
 1.  Open the website in a browser to verify that the website is
     actually responding.
+    
 2.  If you are checking for specific content with a body match, verify
     that the content of the body match actually exists on the page that
     you are viewing.
 
-    Your browser returns the page or it might return another error
-    saying that the site was unreachable or an error code from the
-    web server. Common error codes include the following ones:
+    Your browser returns the page or it might return another error saying that the site was unreachable or an error code from the web server. Following are common error codes:
 
-    -   404, which means that the page was not found.
+    -   404, which means that the page was not found
     -   503, which means that the web server is denying access to the
-        content that you are trying to view.
+        content that you are trying to view
 
 ### Advanced troubleshooting for HTTP checks
 
 Run cURL, a common command-line web page utility, against the website
-that you are checking. This returns the contents of the web page to your
+that you are checking to return the contents of the web page to your
 terminal or shell window. You can explore cURL's options to get more
-specific information, but a useful option is -I. This command returns
+specific information, but a useful option is `-I`. This option returns
 the target web page's headers and the response code from the web server.
-For example, enter the following command in your terminal or shell
-window, replacing your\_domain with your actual domain:
 
-    curl -I http://www.your_domain.com
+For example, enter the following command in your terminal or shell
+window, replacing `yourDomain` with your actual domain:
+
+    curl -I http://www.yourDomain.com
 
 The output should look something like this:
 
@@ -71,32 +70,32 @@ The output should look something like this:
 
 ### TCP checks
 
-TCP checks monitor ports. If an alert is triggered for a TCP check, try
-to use Telnetto communicate with the target or scan your target for the
-open port.
+TCP checks monitor ports. If an alert is triggered for a TCP check, use Telnet to try to communicate with the target or scan your target for the open port.
 
 **Note**: Ensure that you are authorized to scan the target. Many
-network security groups view this type of san as an attack on the open
+network security groups view this type of scan as an attack on the open
 port.
 
 Alternatively, try to directly access the service that is running on
 that port. For example, if the service is an SSH server, try to open an
-**ssh** session to the target host. If the service is running MYSQL or
-Microsoft SQL Server, try to connect to the database. Following is an
-example of how to use Telenet to communicate with the default port
+**ssh** session to the target host. If the service is running MySQL or
+Microsoft SQL Server, try to connect to the database. 
+
+Following is an
+example of how to use Telnet to communicate with the default port
 (3306) for MySQL:
 
     telnet mysql.myhost.com 3306
 
-To exit telnet, type `Ctrl  \]`, press the **Enter** key, and then type `quit`.
+To exit Telnet, type `Ctrl  \]`, press the **Enter** key, and then type `quit`.
 
-### Contact Rackspace Technical Support
+### Other resources
 
-If you're unable to solve the problem using the steps outlined in this
+If you're unable to solve the problem by using the steps outlined in this
 article, review the information in the following documents:
 
 - [Rackspace Monitoring API status code reference](https://developer.rackspace.com/docs/rackspace-monitoring/v1/tech-ref-info/check-type-reference/#check-status-codes)
 
-- [Checks and Alarms](how-to/rackspace-monitoring-checks-and-alarms/)
+- [Rackspace Monitoring Checks and Alarms](/how-to/rackspace-monitoring-checks-and-alarms/)
 
 If you need more assistance, contact [Rackspace Support](https://www.rackspace.com/support).


### PR DESCRIPTION
- Fixes issue #1536 
- Add links for "Monitoring status codes" and "Checks and Alarms"
- Replace all instances of "alarm" with "alert"
- Add further explanation for bad ping responses
- Add link to "common network troubleshooting tools" for ping and traceroute.

Before merging, the article needs to be renamed to reflect new title. A redirect also needs to be added. 
