### PR TITLE
Add Cloud Office CP basics section to intro pages

### DIFF
--- a/content/exchange/index.md
+++ b/content/exchange/index.md
@@ -3,7 +3,7 @@ title: Microsoft Exchange
 type: product
 created_date: '2016-01-17'
 created_by: Rackspace Support
-last_modified_date: '2016-09-22'
+last_modified_date: '2016-11-08'
 last_modified_by: Stephanie Fillmon
 permalink: /exchange/
 product: Microsoft Exchange
@@ -14,16 +14,23 @@ Welcome to Microsoft Exchange hosted by Rackspace! Use this brief step-by-step g
 
 <hr />
 
+###  Control Panel basics
+
+- [Cloud Office Control Panel overview](/how-to/cloud-office-control-panel-overview)
+- [Account information in the Cloud Office Control Panel](/how-to/my-account-cloud-office-control-panel)
+- [General information in the Cloud Office Control Panel](/how-to/general-information-cloud-office-control-panel)
+- [Administrator management: Cloud Office Control Panel](/how-to/administrator-management-cloud-office-control-panel)
+- [View administrator activity in the Cloud Office Control Panel](/how-to/view-administrator-activity-in-the-cloud-office-control-panel)
+- [Cancel Cloud Office services](/how-to/cancel-cloud-office-services)
+- [Upgrades in the Cloud Office Control Panel](/how-to/upgrades-cloud-office-control-panel)
+- [Domains in the Cloud Office Control Panel](/how-to/domains-cloud-office-control-panel)
+- [View invoice history in the Cloud Office Control Panel](/how-to/view-invoice-history-cloud-office-control-panel)
+- [View and pay unpaid invoices in the Cloud Office Control Panel](/how-to/view-and-pay-unpaid-invoices-cloud-office-control-panel)
+- [Set up an API key in the Cloud Office Control Panel](/how-to/set-up-an-api-key-cloud-office-control-panel)
+
 ###  Plan your migration
 
 - [Migration services](/how-to/email-migration-services)
-
-###  Cloud Office Control Panel basics
-
-- [Add Microsoft Exchange mailboxes](/how-to/adding-microsoft-exchange-mailboxes)
-- [Add Rackspace Email mailboxes](/how-to/add-rackspace-email-mailboxes)
-- [Rackspace Email mailbox features](/how-to/exchange-email-mailbox-features)
-- [Exchange Mailbox Features](/how-to/exchange-email-mailbox-features)
 
 ###  Start receiving mail
 

--- a/content/rackspace-email-archiving/index.md
+++ b/content/rackspace-email-archiving/index.md
@@ -3,8 +3,8 @@ title: Rackspace Email Archiving
 type: product
 created_date: '2016-01-17'
 created_by: Rackspace Support
-last_modified_date: '2016-01-26'
-last_modified_by: Catherine Richardson
+last_modified_date: '2016-11-08'
+last_modified_by: Stephanie Fillmon
 permalink: /rackspace-email-archiving/
 product: Rackspace Email Archiving
 product_url: rackspace-email-archiving
@@ -14,7 +14,21 @@ The archiving feature of Rackspace Cloud Office collects and stores external, in
 
 These articles will help you get started using Rackspace Email Archiving through Cloud Office.
 
+<hr />
 
+###  Control Panel basics
+
+- [Cloud Office Control Panel overview](/how-to/cloud-office-control-panel-overview)
+- [Account information in the Cloud Office Control Panel](/how-to/my-account-cloud-office-control-panel)
+- [General information in the Cloud Office Control Panel](/how-to/general-information-cloud-office-control-panel)
+- [Administrator management: Cloud Office Control Panel](/how-to/administrator-management-cloud-office-control-panel)
+- [View administrator activity in the Cloud Office Control Panel](/how-to/view-administrator-activity-in-the-cloud-office-control-panel)
+- [Cancel Cloud Office services](/how-to/cancel-cloud-office-services)
+- [Upgrades in the Cloud Office Control Panel](/how-to/upgrades-cloud-office-control-panel)
+- [Domains in the Cloud Office Control Panel](/how-to/domains-cloud-office-control-panel)
+- [View invoice history in the Cloud Office Control Panel](/how-to/view-invoice-history-cloud-office-control-panel)
+- [View and pay unpaid invoices in the Cloud Office Control Panel](/how-to/view-and-pay-unpaid-invoices-cloud-office-control-panel)
+- [Set up an API key in the Cloud Office Control Panel](/how-to/set-up-an-api-key-cloud-office-control-panel)
 
 ###  Enable and access Email Archiving
 

--- a/content/rackspace-email/index.md
+++ b/content/rackspace-email/index.md
@@ -3,8 +3,8 @@ title: Rackspace Email
 type: product
 created_date: '2016-01-17'
 created_by: Rackspace Support
-last_modified_date: '2016-01-17'
-last_modified_by: Rackspace Support
+last_modified_date: '2016-11-08'
+last_modified_by: Stephanie Fillmon
 permalink: /rackspace-email/
 product: Rackspace Email
 product_url: rackspace-email
@@ -14,16 +14,23 @@ Welcome to Rackspace Email! Use this brief step-by-step guide to help you get st
 
 <hr />
 
+###  Control Panel basics
+
+- [Cloud Office Control Panel overview](/how-to/cloud-office-control-panel-overview)
+- [Account information in the Cloud Office Control Panel](/how-to/my-account-cloud-office-control-panel)
+- [General information in the Cloud Office Control Panel](/how-to/general-information-cloud-office-control-panel)
+- [Administrator management: Cloud Office Control Panel](/how-to/administrator-management-cloud-office-control-panel)
+- [View administrator activity in the Cloud Office Control Panel](/how-to/view-administrator-activity-in-the-cloud-office-control-panel)
+- [Cancel Cloud Office services](/how-to/cancel-cloud-office-services)
+- [Upgrades in the Cloud Office Control Panel](/how-to/upgrades-cloud-office-control-panel)
+- [Domains in the Cloud Office Control Panel](/how-to/domains-cloud-office-control-panel)
+- [View invoice history in the Cloud Office Control Panel](/how-to/view-invoice-history-cloud-office-control-panel)
+- [View and pay unpaid invoices in the Cloud Office Control Panel](/how-to/view-and-pay-unpaid-invoices-cloud-office-control-panel)
+- [Set up an API key in the Cloud Office Control Panel](/how-to/set-up-an-api-key-cloud-office-control-panel)
+
 ###  Plan your migration
 
 - [Email migration services](/how-to/email-migration-services)
-
-###  Control Panel basics
-
-- [Create a Rackspace Email mailbox](/how-to/add-rackspace-email-mailboxes)
-- [Create an Exchange mailbox](/how-to/adding-microsoft-exchange-mailboxes)
-- [Rackspace Email mailbox features](/how-to/rackspace-email-mailbox-features)
-- [Exchange Email mailbox features](/how-to/exchange-email-mailbox-features)
 
 ###  Start receiving email
 

--- a/content/sharepoint/index.md
+++ b/content/sharepoint/index.md
@@ -3,8 +3,8 @@ title: Microsoft SharePoint
 type: product
 created_date: '2016-01-17'
 created_by: Rackspace Support
-last_modified_date: '2016-01-26'
-last_modified_by: Catherine Richardson
+last_modified_date: '2016-11-08'
+last_modified_by: Stephanie Fillmon
 permalink: /sharepoint/
 product: Microsoft SharePoint
 product_url: sharepoint
@@ -13,6 +13,20 @@ product_url: sharepoint
 <p class="lead" markdown="1">Our hosted SharePoint service offers all of the benefits of an online SharePoint site plus access to Rackspace's renowned Fanatical Support.</p>
 
 <hr />
+
+###  Control Panel basics
+
+- [Cloud Office Control Panel overview](/how-to/cloud-office-control-panel-overview)
+- [Account information in the Cloud Office Control Panel](/how-to/my-account-cloud-office-control-panel)
+- [General information in the Cloud Office Control Panel](/how-to/general-information-cloud-office-control-panel)
+- [Administrator management: Cloud Office Control Panel](/how-to/administrator-management-cloud-office-control-panel)
+- [View administrator activity in the Cloud Office Control Panel](/how-to/view-administrator-activity-in-the-cloud-office-control-panel)
+- [Cancel Cloud Office services](/how-to/cancel-cloud-office-services)
+- [Upgrades in the Cloud Office Control Panel](/how-to/upgrades-cloud-office-control-panel)
+- [Domains in the Cloud Office Control Panel](/how-to/domains-cloud-office-control-panel)
+- [View invoice history in the Cloud Office Control Panel](/how-to/view-invoice-history-cloud-office-control-panel)
+- [View and pay unpaid invoices in the Cloud Office Control Panel](/how-to/view-and-pay-unpaid-invoices-cloud-office-control-panel)
+- [Set up an API key in the Cloud Office Control Panel](/how-to/set-up-an-api-key-cloud-office-control-panel)
 
 ###  SharePoint information
 


### PR DESCRIPTION
Fixes #1486 

Adding a section of general Cloud Office Control Panel links to each product intro page, except for Office 365, which I'm pretty sure works differently, and Skype for Business for the same reason.