### PR TITLE
Make metadata example more general

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,15 +60,15 @@ Follow these steps to create a new article within a product folder of the **rack
 
            ---
            permalink: title-of-article/
-           audit_date: 2016-08-22
-           title: Checking cloud status
+           audit_date: 
+           title: Title of article
            type: article
-           created_date: '2016-01-29'
-           created_by: Rosie Contreras
-           last_modified_date: '2016-01-29'
-           last_modified_by: Rosie Contreras
-           product: Cloud Servers
-           product_url: cloud-servers
+           created_date: 'YYYY-MM-DD'
+           created_by: Your name
+           last_modified_date: 'YYYY-MM-DD'
+           last_modified_by: Your name
+           product: Name of product
+           product_url: product-url
            ---
 5. Write your article in Markdown. Markdown guidelines are at https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet.
 


### PR DESCRIPTION
- Not associated with an issue

Open to suggestions on how best to do this. This is something we can easily fix for contributors when we perform reviews, but articles won't build unless metadata is included.