### PR TITLE
remove enums mention as its support is discontinued

### DIFF
--- a/content/rackspace-metrics/create-a-grafana-dashboard-for-rackspace-metrics.md
+++ b/content/rackspace-metrics/create-a-grafana-dashboard-for-rackspace-metrics.md
@@ -146,14 +146,6 @@ complete the following steps:
 #### (Optional) Use Annotation
 With annotation support, users can submit change event to show along with the graph, adding additional information for the graph on the dashboard. See [Use annotation metrics](/how-to/use-annotation-metrics) for additional information.
 
-#### (Optional) Use Enum metrics
-
-The enum metrics release will allow you to push state based metrics (enums) and get the report from API on the frequency of occurrence of the values. For example, a common report for the IT teams to provide the uptime report based on the occurrences of the response codes from the server, or the state of the alerts during a period of time. Enum support is a stepping stone by providing the data to be used in report or visualization.  See [Use enum suport](/how-to/use-enum-metrics-support) for additional information.
-
-For API commands and additonal information about sending enum metrics, see [Sending enum metrics](https://developer.rackspace.com/docs/metrics/v2/developer-guide/#sending-enum-metrics) in the API documentation.
-
-For API command and additional informationon about retrieving enum metrics, see [Retrieving enum metrics](https://developer.rackspace.com/docs/metrics/v2/developer-guide/#retrieving-enum-metrics) in the API documentation.
-
 ### Grafana FAQ
 
 #### How much does Grafana cost?


### PR DESCRIPTION
I am one of the developer in Rackspace Metrics team. We are dropping support for Enums metrics and thus would like to remove any publicly facing articles that mention Enums.

thanks,
-shinta