### PR TITLE
information about how to retrieve the metrics

### DIFF
--- a/content/rackspace-metrics/integrate-statsd-with-rackspace-metrics.md
+++ b/content/rackspace-metrics/integrate-statsd-with-rackspace-metrics.md
@@ -13,6 +13,10 @@ product_url: rackspace-metrics
 
 This article describes how to configure StastD to send metrics to Rackspace Metrics. If you don't have StatsD installed, follow the instructions on the [StatsD Website](https://github.com/etsy/statsd/blob/master/README.md).
 
+The following are the two ways to view the metrics submitted through StatsD.  Plesae note that at this point Rackspace Intelligence does not yet allow visulaziation of any metrics submitted outside Rackspace Monitoring.
+- Use client script calling [Rackspace Metrics Query API](https://developer.rackspace.com/docs/metrics/v2/query-api-reference/) directly.
+- Use [Grafana dashboard](/how-to/create-a-grafana-dashboard-for-rackspace-metrics/)
+
 To configure StatsD for the Rackspace Metrics service, complete the
 following steps:
 

--- a/content/rackspace-metrics/integrate-statsd-with-rackspace-metrics.md
+++ b/content/rackspace-metrics/integrate-statsd-with-rackspace-metrics.md
@@ -5,7 +5,7 @@ title: Integrate StatsD with Rackspace Metrics
 type: article
 created_date: '2015-02-05'
 created_by: Constanze Kratel
-last_modified_date: '2016-07-22'
+last_modified_date: '2016-12-13'
 last_modified_by: Shane Duane
 product: Rackspace Metrics
 product_url: rackspace-metrics
@@ -13,9 +13,12 @@ product_url: rackspace-metrics
 
 This article describes how to configure StastD to send metrics to Rackspace Metrics. If you don't have StatsD installed, follow the instructions on the [StatsD Website](https://github.com/etsy/statsd/blob/master/README.md).
 
-The following are the two ways to view the metrics submitted through StatsD.  Plesae note that at this point Rackspace Intelligence does not yet allow visulaziation of any metrics submitted outside Rackspace Monitoring.
+You can view metrics submitted through StatsD using the following methods:
+
 - Use client script calling [Rackspace Metrics Query API](https://developer.rackspace.com/docs/metrics/v2/query-api-reference/) directly.
 - Use [Grafana dashboard](/how-to/create-a-grafana-dashboard-for-rackspace-metrics/)
+
+**Note:** Rackspace Intelligence does not allow visulaziation of any metrics submitted outside Rackspace Monitoring at this time.
 
 To configure StatsD for the Rackspace Metrics service, complete the
 following steps:


### PR DESCRIPTION
Based on user feedback, added information about ways to visualize the metrics.  Added clarification that Rackspace Intelligence does not yet support StatsD metrics.