### PR TITLE
Add FAWS folder with article template

### DIFF
--- a/content/FAWS/task-based-article-template.md
+++ b/content/FAWS/task-based-article-template.md
@@ -1,0 +1,71 @@
+---
+permalink: article-title/
+audit_date: 'yyyy-mm-dd'
+title: 'Article title'
+type: article
+created_date: 'yyyy-mm-dd'
+created_by: First Last
+last_modified_date: 'yyyy-mm-dd'
+last_modified_by: First Last
+product: Cloud Product
+product_url: cloud-product
+---
+
+Provide a descriptive title for the article that begins with an imperative verb. For example: Restore a server from a snapshot.
+
+Introduce the article by describing the task that the user wants to perform or the issue that the user needs to solve. The primary audience for How-To content are Rackspace customers who might have varying levels of technical expertise.
+
+Write your article in Markdown. You can find Markdown guidelines at https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet.
+
+For general writing guidelines, see the [contribution guidelines](https://github.com/rackerlabs/rackspace-how-to/blob/master/CONTRIBUTING.md).
+
+### Prerequisites (optional)
+
+Include any prerequisites or required system setups. You can use bullets to describe a list of items:
+
+   - Required software
+   - Rackspace account
+   - Required CPU, networking, disk
+
+### Limitations (optional)
+
+Describe any limitations to the task described in this article. For example, the article applies only to Linux systems, or has different requirements based on the environment.
+
+### Procedure (repeat as necessary)
+
+Provide a descriptive heading for this section that begins with an imperative verb. For example: Create a new server.
+
+List steps in numbered order and limit each step to a single action. You can add additional information related to a step in an indented paragraph. For example:
+
+1. Log in to the [Cloud Control Panel](https://mycloud.rackspace.com/).
+2. At the top of the panel, select **Databases > MySQL Instance**.
+3. In the **Identity** section, provide a name for the instance and specify the region in which you want to launch the HA instances that you create.
+
+   The name that you specify and an index (such as -01, -02) are used to create all the instances names, starting with the master index.
+
+3. Create more steps as needed.
+
+       To display code in a block, indent code samples by four spaces in regular text and increase the indent as necessary in lists (as shown here).
+
+Conclude with a brief description of the end state. You can create as many procedure sections as needed to accomplish the task described in the introduction of the article. Be sure to use a descriptive title for each section.
+
+For guidance on when to use diagrams and screenshots, see the [Screenshot and diagram guidelines](http://rackerlabs.github.io/docs-rackspace/style-guide/screenshot-diagram-guidelines.html).
+
+#### Procedure subtopic (repeat as necessary)
+
+Any subtopics related to a procedure should use the next level heading. Follow the preceding guidelines for subtopics.
+
+### Troubleshooting (optional)
+
+Include any troubleshooting information that pertains only to this task. If it might apply to more than one article, create a new article for it and link to that article from here.
+
+### Next steps (optional)
+
+Include any links to articles that your audience should read next.
+
+### Related articles (optional)
+
+Include any links to related content. Use a bulleted list if you have more than one link. For example:
+
+- [Create an image from a server and restore a server from a saved image](/how-to/create-an-image-from-a-server-and-restore-a-server-from-a-saved-image)
+- [About Cloud Server images](/how-to/about-cloud-server-images)


### PR DESCRIPTION
Adding folder with template so that I can point to it from within the FAWS beta migration wiki at https://one.rackspace.com/display/OPS/MT+-+Technical+Documentation