### PR TITLE
add version numbers for 2014 and 2016

### DIFF
--- a/content/cloud-servers/troubleshoot-remote-access-to-sql-server.md
+++ b/content/cloud-servers/troubleshoot-remote-access-to-sql-server.md
@@ -21,8 +21,8 @@ To troubleshoot this issue, open TCP port 1433 for the service itself. If you ne
 
 2. Verify that the SQL Server service is started.
 
-   - *(SQL Server 2005, 2008, 2008 R2)* Select **Start > Administrative Tools > Services**, and verify that the **SQL Server (MSSQLSERVER)** service is started.
-   - *(SQL Server 2012, 2014, 2016)* Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop, select **Administrative Tools > Services**, and verify that the **SQL Server (MSSQLSERVER)** service is started.
+   - *SQL Server 2005, 2008, and 2008 R2*: Select **Start > Administrative Tools > Services**, and verify that the **SQL Server (MSSQLSERVER)** service is started.
+   - *SQL Server 2012, 2014, and 2016*: Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop, select **Administrative Tools > Services**, and verify that the **SQL Server (MSSQLSERVER)** service is started.
 
 3. Ensure that you are using the correct credentials to authenticate. The default SQL Server administrator account is named **sa**. If you built the server from a server image with SQL Server pre-installed, the password is in a text file on the root of the C partition.
 
@@ -32,9 +32,9 @@ To troubleshoot this issue, open TCP port 1433 for the service itself. If you ne
 
 6. Open the SQL Server Configuration Manager as follows:
 
-   - *(SQL Server 2005, 2008, 2008 R2)* Go to **Start > All Programs > Microsoft SQL Server 2005 (or 2008 or 2008 R2) > Configuration Tools > SQL Server Configuration Manager**.
+   - *SQL Server 2005, 2008, and 2008 R2*: Go to **Start > All Programs > Microsoft SQL Server 2005 (or 2008 or 2008 R2) > Configuration Tools > SQL Server Configuration Manager**.
 
-   - *(SQL Server 2012, 2014, 2016)* Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop and select **All Programs > Microsoft SQL Server 2012 > Configuration Tools > SQL Server Configuration Manager**.
+   - *SQL Server 2012, 2014, and 2016*: Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop and select **All Programs > Microsoft SQL Server 2012 (or 2014 or 2016) > Configuration Tools > SQL Server Configuration Manager**.
 
 7. In the navigation pane, expand **SQL Server Network Configuration** and select the protocols for your SQL Server instance.
 

--- a/content/cloud-servers/troubleshoot-remote-access-to-sql-server.md
+++ b/content/cloud-servers/troubleshoot-remote-access-to-sql-server.md
@@ -1,11 +1,11 @@
 ---
 permalink: troubleshoot-remote-access-to-sql-server/
-audit_date:
+audit_date: '2017-02-14'
 title: Troubleshoot remote access to SQL server
 type: article
 created_date: '2011-08-16'
 created_by: Rackspace Support
-last_modified_date: '2016-11-14'
+last_modified_date: '2017-02-14'
 last_modified_by: Stephanie Fillmon
 product: Cloud Servers
 product_url: cloud-servers
@@ -22,7 +22,7 @@ To troubleshoot this issue, open TCP port 1433 for the service itself. If you ne
 2. Verify that the SQL Server service is started.
 
    - *(SQL Server 2005, 2008, 2008 R2)* Select **Start > Administrative Tools > Services**, and verify that the **SQL Server (MSSQLSERVER)** service is started.
-   - *(SQL Server 2012)* Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop, select **Administrative Tools > Services**, and verify that the **SQL Server (MSSQLSERVER)** service is started.
+   - *(SQL Server 2012, 2014, 2016)* Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop, select **Administrative Tools > Services**, and verify that the **SQL Server (MSSQLSERVER)** service is started.
 
 3. Ensure that you are using the correct credentials to authenticate. The default SQL Server administrator account is named **sa**. If you built the server from a server image with SQL Server pre-installed, the password is in a text file on the root of the C partition.
 

--- a/content/cloud-servers/troubleshoot-remote-access-to-sql-server.md
+++ b/content/cloud-servers/troubleshoot-remote-access-to-sql-server.md
@@ -1,17 +1,17 @@
 ---
 permalink: troubleshoot-remote-access-to-sql-server/
-audit_date: '2017-02-14'
-title: Troubleshoot remote access to SQL server
+audit_date: '2017-02-15'
+title: Troubleshoot remote access to SQL Server
 type: article
 created_date: '2011-08-16'
 created_by: Rackspace Support
-last_modified_date: '2017-02-14'
+last_modified_date: '2017-02-15'
 last_modified_by: Stephanie Fillmon
 product: Cloud Servers
 product_url: cloud-servers
 ---
 
-When you can't connect to a Microsoft SQL Server instance remotely through ODBC, Visual Studio, or a SQL Server Management Studio connection, usually the Windows firewall is blocking the access.
+When you can't connect to a Microsoft SQL Server instance remotely through ODBC, Visual Studio, or a SQL Server Management Studio connection, usually the Windows firewall is blocking the access. Use the resolutions in this article to troubleshoot the issue.
 
 ### Open TCP ports
 
@@ -26,28 +26,28 @@ To troubleshoot this issue, open TCP port 1433 for the service itself. If you ne
 
 3. Ensure that you are using the correct credentials to authenticate. The default SQL Server administrator account is named **sa**. If you built the server from a server image with SQL Server pre-installed, the password is in a text file on the root of the C partition.
 
-4. Verify that the server is listening for SQL Server traffic on the correct ports by opening a command prompt and running **netstat -an**.
+4. From a command prompt, run **netstat -an**.
 
-5. If the server is not listening for SQL Server traffic on the correct ports, use the SQL Server Configuration Manager to change the ports.
+5. In the output, verify whether the server is listening for SQL Server traffic on the correct ports (1433 and optionally 1434). If it is not, proceed with the following steps to use the SQL Server Configuration Manager to change the ports.
 
-   1. Open the SQL Server Configuration Manager as follows:
+6. Open the SQL Server Configuration Manager as follows:
 
-      - *(SQL Server 2005, 2008, 2008 R2)* Go to **Start > All Programs > Microsoft SQL Server 2005 (or 2008 or 2008 R2) > Configuration Tools > SQL Server Configuration Manager**.
+   - *(SQL Server 2005, 2008, 2008 R2)* Go to **Start > All Programs > Microsoft SQL Server 2005 (or 2008 or 2008 R2) > Configuration Tools > SQL Server Configuration Manager**.
 
-      - *(SQL Server 2012, 2014, 2016)* Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop and select **All Programs > Microsoft SQL Server 2012 > Configuration Tools > SQL Server Configuration Manager**.
+   - *(SQL Server 2012, 2014, 2016)* Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop and select **All Programs > Microsoft SQL Server 2012 > Configuration Tools > SQL Server Configuration Manager**.
 
-   2. In the navigation pane, expand **SQL Server Network Configuration** and select the protocols for your SQL Server instance.
+7. In the navigation pane, expand **SQL Server Network Configuration** and select the protocols for your SQL Server instance.
 
-   3. In the right pane, right-click **TCP/IP** and select **Properties**.
+8. In the right pane, right-click **TCP/IP** and select **Properties**.
 
-   4. Select the **IP Addresses** tab.
+9. Select the **IP Addresses** tab.
 
-   5. Ensure that all TCP ports mentioned on all interfaces is 1433.
+10. Ensure that all TCP ports mentioned on all interfaces is 1433.
 
-   6. Click **OK**.
+11. Click **OK**.
 
-   7. Restart the SQL Server service.
+12. Restart the SQL Server service.
 
 ### Specify the SQL Server instance name when using named instances
 
- If you are using named instances when installing SQL Server, which gives you the ability to host multiple SQL Server versions or service types, you must specify the name of the SQL Server instance when connecting rather than just using the server's name or IP address. Append the SQL Server instance name to the server's name or IP address, following a backslash. For example, *12.34.56.78\sqlInstanceName* or *sqlServerName\sqlInstanceName*.
+ Named instances give you the ability to host multiple SQL Server versions or service types. If you are using named instances when installing SQL Server, you must specify the name of the SQL Server instance when connecting rather than just using the server's name or IP address. Append the SQL Server instance name to the server's name or IP address, following a backslash. For example, *12.34.56.78\sqlInstanceName* or *sqlServerName\sqlInstanceName*.

--- a/content/cloud-servers/troubleshoot-remote-access-to-sql-server.md
+++ b/content/cloud-servers/troubleshoot-remote-access-to-sql-server.md
@@ -34,7 +34,7 @@ To troubleshoot this issue, open TCP port 1433 for the service itself. If you ne
 
       - *(SQL Server 2005, 2008, 2008 R2)* Go to **Start > All Programs > Microsoft SQL Server 2005 (or 2008 or 2008 R2) > Configuration Tools > SQL Server Configuration Manager**.
 
-      - *(SQL Server 2012)* Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop and select **All Programs > Microsoft SQL Server 2012 > Configuration Tools > SQL Server Configuration Manager**.
+      - *(SQL Server 2012, 2014, 2016)* Use the Windows key or hover the mouse pointer over the lower-left corner of the desktop and select **All Programs > Microsoft SQL Server 2012 > Configuration Tools > SQL Server Configuration Manager**.
 
    2. In the navigation pane, expand **SQL Server Network Configuration** and select the protocols for your SQL Server instance.
 


### PR DESCRIPTION
Fixes #1760 

Nothing changed from 2012 to the 2014 and 2016 versions to require addition text, so just adding the version numbers to the appropriate section.