### PR TITLE
Corrected The MySQL SSL CA Argument

### DIFF
--- a/content/cloud-databases/using-ssl-with-your-cloud-database-instance.md
+++ b/content/cloud-databases/using-ssl-with-your-cloud-database-instance.md
@@ -54,7 +54,7 @@ certificate for SSL connections to your database.
 To make SSL connections using the `mysql` command line client, specify
 the location of the certificate when you start the client:
 
-    mysql -ssl-ca=/path/to/ca-cert.pem
+    mysql --ssl-ca=/path/to/ca-cert.pem
 
 More information about using SSL with MySQL can be found in the [MySQL
 5.6


### PR DESCRIPTION
The argument for setting the SSL CA should be `--ssl-ca=...` not `-ssl-ca=...`

From the [MySQL docs](https://dev.mysql.com/doc/refman/5.6/en/secure-connection-options.html#option_general_ssl-ca):

> 
> --ssl-ca=file_name
> 
> The path to a file in PEM format that contains a list of trusted SSL certificate authorities. This option implies --ssl. 

