### PR TITLE
Update metadata in Dedicated articles

### DIFF
--- a/content/dedicated-hosting/add-new-vpn-user-myrackspace-portal.md
+++ b/content/dedicated-hosting/add-new-vpn-user-myrackspace-portal.md
@@ -2,7 +2,7 @@
 permalink: add-new-vpn-user-myrackspace-portal/
 audit_date:
 title: Add a new VPN user in the MyRackspace Portal
-type: product
+type: article
 created_date: '2016-11-10'
 created_by: Trevor Becker
 last_modified_date: '2016-11-11'

--- a/content/dedicated-hosting/linux-spheres-of-support-for-dedicated-and-managed-ops.md
+++ b/content/dedicated-hosting/linux-spheres-of-support-for-dedicated-and-managed-ops.md
@@ -2,7 +2,7 @@
 permalink: linux-spheres-of-support-for-dedicated-and-managed-ops/
 audit_date: '2017-03-07'
 title: Linux Spheres of Support for Dedicated and Managed Operations
-type: product
+type: article
 created_date: '2017-03-03'
 created_by: Alex Juarez
 last_modified_date: '2017-03-07'

--- a/content/dedicated-hosting/network-device-reboot-faq.md
+++ b/content/dedicated-hosting/network-device-reboot-faq.md
@@ -2,7 +2,7 @@
 permalink: network-device-reboot-faq/
 audit_date: '2017-01-16'
 title: Network device reboot FAQ
-type: product
+type: article
 created_date: '2017-01-16'
 created_by: Trevor Becker
 last_modified_date: '2017-01-16'

--- a/content/dedicated-hosting/rhel-and-centos-subscription-options-in-linux-infrastructures.md
+++ b/content/dedicated-hosting/rhel-and-centos-subscription-options-in-linux-infrastructures.md
@@ -2,7 +2,7 @@
 permalink: rhel-and-centos-subscription-options-in-linux-infrastructures/
 audit_date: '2016-11-09'
 title: Red Hat and CentOS subscription options in Linux infrastructures
-type: product
+type: article
 created_date: '2016-11-02'
 created_by: Stephanie Fillmon
 last_modified_date: '2016-11-09'


### PR DESCRIPTION
The "type" metadata should say article instead of product for all of the dedicated articles.

