### PR TITLE
repair broken links

### DIFF
--- a/content/rpc-openstack/index.md
+++ b/content/rpc-openstack/index.md
@@ -14,35 +14,34 @@ Rackspace has developed a set of tools that allow you to quickly install an Open
 
 Rackspace Private Cloud Software uses Ansible to create an OpenStack cluster on Ubuntu Linux. The installation process provides a familiar approach for Linux system administrators, and the environment can be updated easily without downloading and installing a new ISO.
 
-You can learn more about Rackspace Private Cloud and OpenStack [on the main product page](https://www.rackspace.com/cloud/private/openstacksolutions). You can also find Rackspace Private Cloud developer documentation on the [Rackspace Private Cloud Documentation page.](https://developer.rackspace.com/docs/#docs-private-cloud)
+You can learn more about Rackspace Private Cloud and OpenStack [on the main product page](https://www.rackspace.com/openstack/private). You can also find Rackspace Private Cloud developer documentation on the [Rackspace Private Cloud Documentation page.](https://developer.rackspace.com/docs/#docs-private-cloud)
 
 <hr />
 
 ###  General resources
 
-- [FAQ](https://support.rackspace.com/how-to/rpc-openstack-faq/)
-- [Rackspace Private Cloud Software and Reference Architecture](http://www.rackspace.com/cloud/private/openstack/software/)
-- [Rackspace Private Cloud Support](http://www.rackspace.com/cloud/private/openstack/support/)
-- [Rackspace Private Cloud Resources](http://www.rackspace.com/cloud/private/openstack/resources/)
-- [Rackspace Training](http://training.rackspace.com/)
+- [FAQ](how-to/rpc-openstack-faq/)
+- [Rackspace Private Cloud Support](https://www.rackspace.com/support)
+- [Rackspace Private Cloud Software and Reference Architecture](https://www.rackspace.com/openstack/private/openstack)
+- [Rackspace Private Cloud Resources](https://www.rackspace.com/openstack/private/resources)
+- [Rackspace Training](https://www.rackspace.com/openstack/private/training)
 
 ###  Rackspace Private Cloud v13 (Mitaka)
 
 - [Release Notes](https://developer.rackspace.com/docs/private-cloud/rpc/v13/rpc-releasenotes/)
-- [OpenStack Ansible Installation Guide](http://docs.openstack.org/developer/openstack-ansible/mitaka/) - For the Rackspace Private Cloud Installation Guide, contact [Rackspace Private Cloud Support](http://www.rackspace.com/cloud/private/openstack/support/).
+- [OpenStack Ansible Installation Guide](http://docs.openstack.org/developer/openstack-ansible/mitaka/) - For the Rackspace Private Cloud Installation Guide, contact [Rackspace Private Cloud Support](https://www.rackspace.com/support).
 - [Object Storage Deployment Guide](https://developer.rackspace.com/docs/private-cloud/rpc/v13/rpc-swift)
 - [Technical FAQ](https://developer.rackspace.com/docs/private-cloud/rpc/v13/rpc-faq-external/)
 
 ###  Rackspace Private Cloud v12 (Liberty)
 
 - [Release Notes](https://developer.rackspace.com/docs/private-cloud/rpc/v12/rpc-releasenotes/)
-- [OpenStack Ansible Installation Guide](http://docs.openstack.org/developer/openstack-ansible/liberty/) - For the Rackspace Private Cloud Installation Guide, contact [Rackspace Private Cloud Support](http://www.rackspace.com/cloud/private/openstack/support/).
+- [OpenStack Ansible Installation Guide](http://docs.openstack.org/developer/openstack-ansible/liberty/) - For the Rackspace Private Cloud Installation Guide, contact [Rackspace Private Cloud Support](https://www.rackspace.com/support).
 - [Object Storage Deployment Guide](https://developer.rackspace.com/docs/private-cloud/rpc/v12/rpc-swift)
 - [Technical FAQ](https://developer.rackspace.com/docs/private-cloud/rpc/v12/rpc-faq-external/)
 
 ###  Rackspace Private Cloud v11 (Kilo)
 
 - [Release Notes](https://developer.rackspace.com/docs/private-cloud/rpc/v11/rpc-releasenotes)
-- [OpenStack Ansible Installation Guide](http://docs.openstack.org/developer/openstack-ansible/kilo/) - For the Rackspace Private Cloud Installation Guide, contact [Rackspace Private Cloud Support](http://www.rackspace.com/cloud/private/openstack/support/).
 - [Object Storage Deployment Guide](https://developer.rackspace.com/docs/private-cloud/rpc/v11/rpc-swift)
 - [Technical FAQ](https://developer.rackspace.com/docs/private-cloud/rpc/v11/rpc-faq-external/)


### PR DESCRIPTION
Fixes #1936 

Repair broken links on the RPC - OpenStack intro page

Note, the OpenStack support page on rackspace.com doesn't exist anymore, so I changed the link to the main support page, which lists the contact info for RPC support.

Also, the OpenStack Ansible installation guide for Kilo is gone. I guess it passed EOL?