### PR TITLE
updated to fit "General Purpose" flavor

### DIFF
--- a/content/cloud-servers/before-you-move-to-general-purpose-or-io-cloud-server-checklist.md
+++ b/content/cloud-servers/before-you-move-to-general-purpose-or-io-cloud-server-checklist.md
@@ -5,8 +5,8 @@ title: Before you move to General Purpose or I/O Cloud Server (checklist)
 type: article
 created_date: '2013-11-04'
 created_by: David Hendler
-last_modified_date: '2016-09-09'
-last_modified_by: Kyle Laffoon
+last_modified_date: '2017-04-18'
+last_modified_by: Brian King
 product: Cloud Servers
 product_url: cloud-servers
 ---
@@ -18,31 +18,23 @@ that you need to consider to ensure that you are ready to move.
 
 ### Premigration considerations
 
-General Purpose Cloud Servers cannot be resized, so ensuring that your
-architecture is correct from the start is important. Best practices
-include splitting your web and application servers from your database
+Best practices include splitting your web and application servers from your database
 server and putting them behind a load balancer. This split will enable
 you to easily scale horizontally in the future without the need for
 downtime or requiring DNS changes.
 
 ### Premigration actions
 
--   If you have a Cloud Server, you might be able to
-    create an image to migrate to General Purpose Cloud Servers.
-    - For a 512 MB server, create a 1 GB or larger General Purpose Cloud Server via image.
-    - For a 1 GB server, create a 2 GB or larger General Purpose Cloud Server via image.
-    - For a 2 GB or larger server, you cannot use an image to build a General Purpose Cloud Server.
--   Ensure that any automation you have set up allows for a 40 GB system drive.
--   Audit your current and future storage needs to determine how to best
-    organize the data with the General Purpose Cloud
-    Server configuration. You will have multiple disks instead of a
-    single monolithic disk. Consider the following options:
-    -   Use the system disk only.
-    -   Use both the system and data disk.
-    -   Create a single RAID 0 volume out of the multiple data disks on
-        larger servers.
-    -   Leverage Cloud Block Storage for portability.
--   If you use Cloud Backup, ensure that all of your data is backed up
-    when you create your new General Purpose Cloud Server.
--   If you have disk monitoring set up, you must set up monitoring for
-    your system disk and data disk or disks separately.
+-   Migrating from "Standard" or "Classic" flavors
+    - An image from a Classic or Standard server can build a server that is "next size up" in General Purpose. For example, a 1 GB Standard server image can build a 2 GB General Purpose server. If your Standard or Classic server is 8 GB or above, you cannot do an image-based migration due to the larger disk allotment on the older flavors. If you have an older Linux server, you may be able to resize down to 4 GB or smaller, then create an image that will build a General Purpose server.
+
+-  Migrating from "Performance" flavors 
+    - Any Performance server image can build a General Purpose server. However, 2 GB and larger Performance servers have a data disk that is not captured when you image the server. Thus, you must copy the data from the data disks manually via rsync, Robocopy or some other method.
+    
+-  Understand the flavor differences in resizing policy
+    - General Purpose servers can resize, but only up, and only to a maximum size of 8 GB RAM/160 GB. Rather than resizing, we recommend scaling horizontally (adding multiple cloud servers) instead of vertically (making a single cloud server) as this increases the fault tolerance of your application.
+    - Standard and Classic servers can resize up to 30 GB/1.2TB. Some Linux servers may be able to 
+    
+-   If you use Cloud Backup, ensure that all of your data is backed up on your current server, and test a restore.
+
+-   Before deleting the current server, build a test server from your image and verify that it boots correctly.

--- a/content/cloud-servers/before-you-move-to-general-purpose-or-io-cloud-server-checklist.md
+++ b/content/cloud-servers/before-you-move-to-general-purpose-or-io-cloud-server-checklist.md
@@ -12,28 +12,28 @@ product_url: cloud-servers
 ---
 
 General Purpose and I/O-optimized Cloud Servers offer an increase in
-drive and networking speed,but there are some factors to consider before
-moving your current environment. This checklist provides information
+drive and networking speed, but there are some factors to consider before
+moving your current environment. This article provides information
 that you need to consider to ensure that you are ready to move.
 
 ### Premigration considerations
 
-Best practices include splitting your web and application servers from your database
+Consider splitting your web and application servers from your database
 server and putting them behind a load balancer. This split will enable
 you to easily scale horizontally in the future without the need for
-downtime or requiring DNS changes.
+downtime or DNS changes.
 
 ### Premigration actions
 
 -   Migrating from "Standard" or "Classic" flavors
-    - An image from a Classic or Standard server can build a server that is "next size up" in General Purpose. For example, a 1 GB Standard server image can build a 2 GB General Purpose server. If your Standard or Classic server is 8 GB or above, you cannot do an image-based migration due to the larger disk allotment on the older flavors. If you have an older Linux server, you may be able to resize down to 4 GB or smaller, then create an image that will build a General Purpose server.
+    - An image from a Classic or Standard server can build a General Purpose server that is one size larger. For example, a 1 GB Standard server image can build a 2 GB General Purpose server. If your Standard or Classic server is 8 GB or larger, you can’t perform an image-based migration because of the larger disk allotment on the older flavors. If you have an older Linux server, you might be able to resize it down to 4 GB or smaller, and then create an image that will build a General Purpose server.
 
 -  Migrating from "Performance" flavors 
     - Any Performance server image can build a General Purpose server. However, 2 GB and larger Performance servers have a data disk that is not captured when you image the server. Thus, you must copy the data from the data disks manually via rsync, Robocopy or some other method.
     
--  Understand the flavor differences in resizing policy
-    - General Purpose servers can resize, but only up, and only to a maximum size of 8 GB RAM/160 GB. Rather than resizing, we recommend scaling horizontally (adding multiple cloud servers) instead of vertically (making a single cloud server) as this increases the fault tolerance of your application.
-    - Standard and Classic servers can resize up to 30 GB/1.2TB. Some Linux servers may be able to 
+-  Understand how resizing works
+    - General Purpose servers can resize, but only up, and only to a maximum size of 8 GB RAM/160 GB system disk. Rather than resizing (scaling vertically), we recommend scaling horizontally (adding multiple cloud servers) which increases the fault tolerance of your application.
+    - Standard and Classic servers can resize up to 30 GB RAM/1.2 TB system disk. 
     
 -   If you use Cloud Backup, ensure that all of your data is backed up on your current server, and test a restore.
 

--- a/content/cloud-servers/considerations-for-migrating-to-a-general-purpose-or-io-cloud-server.md
+++ b/content/cloud-servers/considerations-for-migrating-to-a-general-purpose-or-io-cloud-server.md
@@ -1,7 +1,7 @@
 ---
-permalink: before-you-move-to-general-purpose-or-io-cloud-server-checklist/
-audit_date:
-title: Before you move to General Purpose or I/O Cloud Server (checklist)
+permalink: considerations-for-migrating-to-a-general-purpose-or-io-cloud-server/
+audit_date: '2017-04-21'
+title: Considerations for migrating to a General Purpose or I/O cloud server
 type: article
 created_date: '2013-11-04'
 created_by: David Hendler


### PR DESCRIPTION
Same problem as previously cited, we did a find/replace from "Performance" to "General Purpose," but the disk allotment and resize policy are drastically different between these flavors, so there is a lot of inaccurate information.

