### PR TITLE
[RPC-OpenStack] Add RPC security doc to index

### DIFF
--- a/content/rpc-openstack/index.md
+++ b/content/rpc-openstack/index.md
@@ -21,6 +21,7 @@ You can learn more about Rackspace Private Cloud and OpenStack [on the main prod
 ###  General resources
 
 - [FAQ](how-to/rpc-openstack-faq/)
+- [Security for Rackspace Private Cloud](/how-to/security-for-rackspace-private-cloud-powered-by-openstack/)
 - [Rackspace Private Cloud Support](https://www.rackspace.com/support)
 - [Rackspace Private Cloud Software and Reference Architecture](https://www.rackspace.com/openstack/private/openstack)
 - [Rackspace Private Cloud Resources](https://www.rackspace.com/openstack/private/resources)


### PR DESCRIPTION
The RPC security documentation is difficult to find and it
requires a reader to click "All Articles" on the left margin
to find it.

This patch puts the link in the RPC documentation index so that it
is much easier to find.

