### PR TITLE
Retire Rackspace Email Features article

### DIFF
--- a/content/rackspace-email/adding-a-rackspace-email-group-list.md
+++ b/content/rackspace-email/adding-a-rackspace-email-group-list.md
@@ -5,14 +5,15 @@ title: Add a Rackspace Email group list
 type: article
 created_date: '2012-05-23'
 created_by: Rackspace Support
-last_modified_date: '2012-07-24'
+last_modified_date: '2017-08-16'
 last_modified_by: Rackspace Support
 product: Rackspace Email
 product_url: rackspace-email
 ---
 
-This article shows how to create a group list. A group list can be used to email a large quantity of people by assigning them to a parent
-email list.
+A group list is a great way to manage users in a select team or group on your domain. There is no limit to the number of internal address (addresses within your domain) and a limit of 250 additional members outside of the domain. For example, suppose that you have a billing team you want to group together - bob@domain.com, amy@domain.com, and scott@domain.com. You can create a group list for the team so that they can communicate new upcoming billing updates within the team, at billingupdates@domain.com.
+
+This article shows how to create a group list.
 
 1. Log in to the [Cloud Office Control Panel](https://cp.rackspace.com).
 2. In the Rackspace Email section, click **Group Lists**.

--- a/content/rackspace-email/adding-an-alias-with-rackspace-email.md
+++ b/content/rackspace-email/adding-an-alias-with-rackspace-email.md
@@ -5,13 +5,15 @@ title: Add an alias with Rackspace Email
 type: article
 created_date: '2012-01-18'
 created_by: Rae D. Cabello
-last_modified_date: '2015-12-29'
+last_modified_date: '2017-08-16'
 last_modified_by: Nate Archer
 product: Rackspace Email
 product_url: rackspace-email
 ---
 
-This article shows how to create an alias that can be used like a mailbox that will forward to another mailbox or to multiple mailboxes on a domain.
+Aliases are a way to create an alternate name for an existing mailbox. For example, John likes to go by Johnny and would like to receive emails to both John@domain.com, for business partners, and Johnny@domain.com, for friends and family, without checking two different accounts.
+
+This article shows how to create an alias that will forward to another mailbox or to multiple mailboxes on a domain.
 
 ### Add a single alias
 

--- a/content/rackspace-email/rackspace-webmail.md
+++ b/content/rackspace-email/rackspace-webmail.md
@@ -5,14 +5,14 @@ title: Rackspace Webmail overview
 type: article
 created_date: '2012-05-27'
 created_by: Rackspace Support
-last_modified_date: '2017-06-13'
-last_modified_by: Cory Aldrich
+last_modified_date: '2017-08-16'
+last_modified_by: Nate Archer
 product: Rackspace Email
 product_url: rackspace-email
 ---
 
 Rackspace Email allows you to check and manage their email online
-through a Webmail interface. Webmail provides a fully functional calendar with the ability to manage contacts as well as syncing them to your mobile device. Webmail also allows you to reset passwords, create filters, add signatures and much much more.
+through a Webmail interface. Webmail is a direct connection to your email without the need of additional software. Messages that are sent and received using Webmail will be waiting for you the next time you log into the portal. The Webmail portal provides most of the same functionality a mail client would offer, from sending and receiving email to setting up email signatures and even setting up email forwarding to your personal email accounts.
 
 ### Log in to Webmail
 
@@ -64,7 +64,7 @@ Rackspace Email provides various options for users to manage their email account
 
 #### Composing Email: Composing
 
-- **Composing** provides various options to choose from, such as auto-completing email addresses when composing a new email, setting up custom signatures, and so on. 
+- **Composing** provides various options to choose from, such as auto-completing email addresses when composing a new email, setting up custom signatures, and so on.
 - **Replying & Forwarding Citations** selects whether you want the original composed message to be included in your reply and to set a user defined start text and end text of your choice.
 
 <img src="{% asset_path rackspace-email/rackspace-webmail/Webmail2.png %}" alt="" />

--- a/content/retired-articles/rackspace-email-mailbox-features.md
+++ b/content/retired-articles/rackspace-email-mailbox-features.md
@@ -5,10 +5,8 @@ title: Rackspace Email mailbox features
 type: article
 created_date: '2014-08-25'
 created_by: Marco Salazar
-last_modified_date: '2014-08-29'
-last_modified_by: Kyle Laffoon
-product: Rackspace Email
-product_url: rackspace-email
+last_modified_date: '2017-08-16'
+last_modified_by: Nate Archer
 ---
 
 Rackspace Email is Rackspace's email service. We manage the


### PR DESCRIPTION
Will make sure these conform to Cloud Office style and standards at a later date.

The same must be done for Exchange Mailbox features article.

Fixes issue #2051 

