### PR TITLE
Update adding-a-rackspace-email-group-list.md

### DIFF
--- a/content/rackspace-email/adding-a-rackspace-email-group-list.md
+++ b/content/rackspace-email/adding-a-rackspace-email-group-list.md
@@ -20,5 +20,5 @@ This article shows how to create a group list.
 3. On the Group Lists page, click **Add Group List**.
 4. Enter in an email address for your group list, enter a subject tag, and select a list type. You can choose to send replies to the sender only or send replies to the entire group list.
 5. Select the recipients to include in the group list. You can add recipients outside your domain.
-6. Select who will be authorized to send email from this group list.
+6. Select who will be authorized to send email to this group list.
 7. Click **Save**.


### PR DESCRIPTION
Updating Item # 6. Changing the sentence from "Select who will be authorized to send email from this group list" to "Select who will be authorized to send email to this group list"

The change is needed to ensure that email Administrators understand Group Lists have limitations on who can send email TO them. No user can send FROM a Group List in Rackspace Email based on these Group List settings. Item # 6 was misleading users to believe that this would allow them to send AS the Group List (from the group list) and not TO the Group List. This also lead to users believing that any email address, on any domain, can send email to a Rackspace Email Group List. This is not true. Only users in the domain, and external users that the the administrator specifies, can send emails to Rackspace Email Group Lists.

