### PR TITLE
The confusion of making a https CDN out of http only origin URL

### DIFF
--- a/content/rackspace-cdn/cdn-enable-amazon-s3-buckets-and-accelerate-your-website-with-rackspace-cdn.md
+++ b/content/rackspace-cdn/cdn-enable-amazon-s3-buckets-and-accelerate-your-website-with-rackspace-cdn.md
@@ -79,7 +79,7 @@ perform the following actions:
 
    For information about creating a new Rackspace CDN service, see [Create a Rackspace CDN service](/how-to/create-a-rackspace-cdn-service).
 
-2. When you specify the origin, enter the URL of your Amazon S3 bucket as your origin domain. For example, `yourBucket.s3.amazonaws.com`.
+2. When you specify the origin, enter the URL of your Amazon S3 bucket as your origin domain. For example, `yourBucket.s3.amazonaws.com`. (Choose http type and not https type, since s3 static site does not support https)
 
 3. Set the **Host Header** type to **Origin**.
 


### PR DESCRIPTION
I have made changes that shows that in Rackspace CDN you can only make http CDN endpoint and not https with s3 static site. 

If it is in fact possible to create https CDN endpoint for s3 static site then please show how. (It is possible to do so in cloudfront and cloudflare with s3 static site)

