### PR TITLE
move retired article to correct folder and fix metadata

### DIFF
--- a/content/retired-articles/use-a-custom-kernel-with-pv-grub.md
+++ b/content/retired-articles/use-a-custom-kernel-with-pv-grub.md
@@ -7,8 +7,6 @@ created_date: '2015-07-27'
 created_by: Rackspace Support
 last_modified_date: '2016-02-04'
 last_modified_by: Stephanie Fillmon
-product: Cloud Servers
-product_url: cloud-servers
 ---
 
 **Note:** During 2015, all First Generation cloud servers will be migrated to Next Generation cloud servers on a rolling basis. Therefore, the instructions listed in this article might or might not work depending on whether your servers have been migrated. If you have questions about the server migration, see [First Generation to Next Generation Cloud Servers migration FAQ](/how-to/first-generation-to-next-generation-cloud-server-migration-faq). If you need assistance with using a custom kernel, contact Rackspace Support at 1 800 961 4454.


### PR DESCRIPTION
discovered that this article I was going to do a full audit on had been retired months ago, but the article wasn't moved to the retired articles folder.