### PR TITLE
change 3rd to 2nd person, fix typos, change mobilesync references to rse+

### DIFF
--- a/content/rackspace-email/rackspace-webmail.md
+++ b/content/rackspace-email/rackspace-webmail.md
@@ -1,34 +1,36 @@
 ---
 permalink: rackspace-webmail/
-audit_date: '2017-07-05'
+audit_date: '2017-12-11'
 title: Rackspace Webmail overview
 type: article
 created_date: '2012-05-27'
 created_by: Rackspace Support
-last_modified_date: '2017-11-26'
-last_modified_by: Paige Warmker
+last_modified_date: '2017-12-11'
+last_modified_by: Cat Lookabaugh
 product: Rackspace Email
 product_url: rackspace-email
 ---
 
-Rackspace Email allows you to check and manage your email online through a webmail interface. Webmail provides direct access to your email without the need for additional software. Messages that are sent and received using webmail wait on the portal until the next time you log in. The webmail portal provides most of the same functionality that a mail client offers, from sending and receiving email to setting up email signatures and even setting up email forwarding to your personal email accounts.
+With Rackspace Email, you can check and manage your email online through a webmail interface. Webmail provides direct access to your email without the need for additional software. Messages that are sent and received using webmail wait on the portal until the next time you log in. The webmail portal provides most of the same functionality that a mail client offers, including sending and receiving email, signatures, and email forwarding.
+
+This article provides and overview of the available features in the Rackspace Email webmail interface.
 
 ### Log in to webmail
 
 To log in to webmail, go to <https://apps.rackspace.com/>.
 
-When you log in, Rackspace allows several options:
+When you log in, Rackspace provides the following options:
 
-- **Remember this info** - Allow Rackspace to interact with your browser to remember your login information
-- **Use SSL** - SSL stands for Secure Socket Layer, which means when you log in, your data is encrypted
+- **Remember this info** - Select teh checkbox to allow Rackspace to interact with your browser to remember your login information
+- **Use SSL** - SSL stands for Secure Socket Layer, which means when you log in, your data is encrypted. Select the checkbox to enable SSL.
 
 ### Contacts
 
-Rackspace Email provides the ability to manage your contacts through our webmail interface. You have the ability to add new contacts, import and export old contacts using a **.csv** file, export to various email clients, create groups, and sort through contacts alphabetically. Rackspace also allows you to sync your contacts with your mobile device and with Rackspace Email Plus.
+Rackspace Email provides the ability to manage your contacts through our webmail interface. You can add new contacts, import and export old contacts using a **.csv** file, export to various email clients, create groups, and sort through contacts alphabetically. You can also sync your contacts with your mobile device and with Rackspace Email Plus.
 
 ### Calendar
 
-Rackspace Email allows you to manage your appointments and meetings through our webmail interface. You can share your calendar, create personal calendars, import events and add shared calendars within your domain. Rackspace also allows you to sync your calendar events with your mobile device as well with Rackspace Email Plus.
+Rackspace Email enables you to manage your appointments and meetings through our webmail interface. You can share your calendar, create personal calendars, import events and add shared calendars within your domain. You can also sync your calendar events with your mobile device as well with Rackspace Email Plus. For more information about Rackspace Email Plus, see [Rackspace Email Plus featuring Cloud Drive](https://www.rackspace.com/en-us/email- hosting/webmail/cloud-drive).
 
 ### Tasks
 
@@ -36,64 +38,78 @@ Rackspace Email provides the ability to create and manage tasks and create task 
 
 ### Notes
 
-Rackspace Email provides the ability to create notes, syncing your notes with your mobile device and with Rackspace Email Plus.
+Rackspace Email provides the ability to create notes, and sync them with your mobile device and with Rackspace Email Plus.
 
 ### Settings
 
 Rackspace Email provides various options for you to manage your email account. While in the webmail interface, click the menu beside your email address in the top-right corner and select **Settings** to see a list of features and options available.
 
-#### General Settings: Email options
+#### General Settings: 
+
+In the General Settings section, you can manage settings for email options, your calendar, and your preferred language and date and time settings.
+
+<img src="{% asset_path rackspace-email/rackspace-webmail/Webmail.png %}" alt="" />
+
+##### Email options
 
 - **Display Preferences** provides several options for you to display HTML emails, enable shortcuts, change your viewing pane, and change the number of messages displayed in your reading pane.
 - **New Messages** provides the option to play an alert for the arrival of new messages and the option to choose how often to check for new messages.
 - **Trash Options** provides the option to move deleted email to the trash or immediately purge upon deletion.
 
-<img src="{% asset_path rackspace-email/rackspace-webmail/Webmail.png %}" alt="" />
-
-#### General Settings: Calendar
+##### Calendar
 
 - **Invitations** provides the option to delete invitations after responding.
 
-#### General Settings: Language & Date/Time
+##### Language & Date/Time
 
 - **Language** provides the option to choose between 11 different languages.
 - **Date and Time** provides the options to set your date, time, and current time zone.
 
-#### Composing Email: Composing
+#### Composing Email
+
+In the **Composing Email** section, you can manage settings for composing, identities, and signatures.
+
+<img src="{% asset_path rackspace-email/rackspace-webmail/Webmail2.png %}" alt="" />
+
+###### Composing
 
 - **Composing** provides various options to choose from, such as auto-completing email addresses when composing a new email, setting up custom signatures, and so on.
 - **Replying & Forwarding Citations** selects whether you want the original composed message to be included in your reply and to set a user defined start text and end text of your choice.
 
-<img src="{% asset_path rackspace-email/rackspace-webmail/Webmail2.png %}" alt="" />
-
-#### Composing Email: Identities
+##### Identities
 
 - **Add New Identity** creates a new identity, which enables you to quickly change the name, email address, and reply address on your outgoing email.
 
-#### Composing Email: Signatures
+##### Signatures
 
 - **Add New Signature** adds a new signature and assign it to your outgoing email and also to specific identities. To learn more, see [Add a Rackspace Email signature](/how-to/adding-a-signature-to-rackspace-email).
 
 #### Incoming Email
 
+In the **Incoming Email** section, you can manage settings for auto-reply, forwarding, and filtering.
+
+<img src="{% asset_path rackspace-email/rackspace-webmail/Webmail3.png %}" alt="" />
+
 - **Auto-Reply** activates the auto-reply feature for times when you are out of the office.
 - **Forwarding** forwards any mail to any email address with the option to save a copy in your inbox.
 - **Filtering** provides the ability to create filters for specific incoming email and to route them to a specified folder.
 
-<img src="{% asset_path rackspace-email/rackspace-webmail/Webmail3.png %}" alt="" />
+#### Spam Settings
 
-#### Spam Settings: Preferences
+In the Spam Settings section, you can manage settings for spam preferences, and safelists and blacklists.
+
+<img src="{% asset_path rackspace-email/rackspace-webmail/Webmail4.png %}" alt="" />
+
+##### Preferences
 
 - **Spam Filtering** turns your spam filtering on and off, or have it be exclusive.
 - **Spam Handling** specifies how you would like your spam email to be handled.
 
-<img src="{% asset_path rackspace-email/rackspace-webmail/Webmail4.png %}" alt="" />
-
-#### Spam Settings: Safelist and Blacklist
+##### Safelist and Blacklist
 
 - **Safelist** specifies what email should be by passed through filters through the sent user's IP address, email address, or domain.
 - **Blacklist** specifies what email should be blocked through the sent user's IP address, email address, or domain.
 
-#### Change Password
+##### Change Password
 
-**Change Password** changes your password. Selecting this option redirects you away from Webmail.
+In the **Change Password** section, you can change your password. Selecting this option redirects you away from webmail.

--- a/content/rackspace-email/rackspace-webmail.md
+++ b/content/rackspace-email/rackspace-webmail.md
@@ -13,7 +13,7 @@ product_url: rackspace-email
 
 With Rackspace Email, you can check and manage your email online through a webmail interface. Webmail provides direct access to your email without the need for additional software. Messages that are sent and received using webmail wait on the portal until the next time you log in. The webmail portal provides most of the same functionality that a mail client offers, including sending and receiving email, signatures, and email forwarding.
 
-This article provides and overview of the available features in the Rackspace Email webmail interface.
+This article provides an overview of the available features in the Rackspace Email webmail interface.
 
 ### Log in to webmail
 
@@ -21,7 +21,7 @@ To log in to webmail, go to <https://apps.rackspace.com/>.
 
 When you log in, Rackspace provides the following options:
 
-- **Remember this info** - Select teh checkbox to allow Rackspace to interact with your browser to remember your login information
+- **Remember this info** - Select the checkbox to allow Rackspace to interact with your browser to remember your login information.
 - **Use SSL** - SSL stands for Secure Socket Layer, which means when you log in, your data is encrypted. Select the checkbox to enable SSL.
 
 ### Contacts
@@ -30,11 +30,11 @@ Rackspace Email provides the ability to manage your contacts through our webmail
 
 ### Calendar
 
-Rackspace Email enables you to manage your appointments and meetings through our webmail interface. You can share your calendar, create personal calendars, import events and add shared calendars within your domain. You can also sync your calendar events with your mobile device as well with Rackspace Email Plus. For more information about Rackspace Email Plus, see [Rackspace Email Plus featuring Cloud Drive](https://www.rackspace.com/en-us/email- hosting/webmail/cloud-drive).
+Rackspace Email enables you to manage your appointments and meetings through our webmail interface. You can share your calendar, create personal calendars, import events, and add shared calendars within your domain. You can also sync your calendar events with your mobile device, as well with Rackspace Email Plus. For more information about Rackspace Email Plus, see [Rackspace Email Plus featuring Cloud Drive](https://www.rackspace.com/en-us/email- hosting/webmail/cloud-drive).
 
 ### Tasks
 
-Rackspace Email provides the ability to create and manage tasks and create task lists through our Webmail interface. 
+Rackspace Email provides the ability to create and manage tasks and to create task lists through our Webmail interface. 
 
 ### Notes
 
@@ -46,7 +46,7 @@ Rackspace Email provides various options for you to manage your email account. W
 
 #### General Settings: 
 
-In the General Settings section, you can manage settings for email options, your calendar, and your preferred language and date and time settings.
+In the General Settings section, you can manage settings for email options, your calendar, your preferred language, and date and time settings.
 
 <img src="{% asset_path rackspace-email/rackspace-webmail/Webmail.png %}" alt="" />
 
@@ -82,7 +82,7 @@ In the **Composing Email** section, you can manage settings for composing, ident
 
 ##### Signatures
 
-- **Add New Signature** adds a new signature and assign it to your outgoing email and also to specific identities. To learn more, see [Add a Rackspace Email signature](/how-to/adding-a-signature-to-rackspace-email).
+- **Add New Signature** adds a new signature and assigns it to your outgoing email and also to specific identities. To learn more, see [Add a Rackspace Email signature](/how-to/adding-a-signature-to-rackspace-email).
 
 #### Incoming Email
 
@@ -96,7 +96,7 @@ In the **Incoming Email** section, you can manage settings for auto-reply, forwa
 
 #### Spam Settings
 
-In the Spam Settings section, you can manage settings for spam preferences, and safelists and blacklists.
+In the Spam Settings section, you can manage settings for spam preferences, safelists, and blacklists.
 
 <img src="{% asset_path rackspace-email/rackspace-webmail/Webmail4.png %}" alt="" />
 

--- a/content/rackspace-email/rackspace-webmail.md
+++ b/content/rackspace-email/rackspace-webmail.md
@@ -11,11 +11,11 @@ product: Rackspace Email
 product_url: rackspace-email
 ---
 
-Rackspace Email allows you to check and manage your email online through a Webmail interface. Webmail is a direct connection to your email without the need for additional software. Messages that are sent and received using Webmail will be waiting for you the next time you log into the portal. The Webmail portal provides most of the same functionality a mail client would offer, from sending and receiving email to setting up email signatures and even setting up email forwarding to your personal email accounts.
+Rackspace Email allows you to check and manage your email online through a webmail interface. Webmail provides direct access to your email without the need for additional software. Messages that are sent and received using webmail wait on the portal until the next time you log in. The webmail portal provides most of the same functionality that a mail client offers, from sending and receiving email to setting up email signatures and even setting up email forwarding to your personal email accounts.
 
-### Log in to Webmail
+### Log in to webmail
 
-To log in to Webmail, go to <https://apps.rackspace.com/>.
+To log in to webmail, go to <https://apps.rackspace.com/>.
 
 When you log in, Rackspace allows several options:
 
@@ -24,27 +24,27 @@ When you log in, Rackspace allows several options:
 
 ### Contacts
 
-Rackspace Email provides the ability to manage your contacts through our Webmail interface. You have the ability to add new contacts, import and export old contacts using a **.csv** file, export to various email clients, create groups, and sort through contacts alphabetically. Rackspace also allows you to sync your contacts with your mobile device as well with Rackspace Email Plus.
+Rackspace Email provides the ability to manage your contacts through our webmail interface. You have the ability to add new contacts, import and export old contacts using a **.csv** file, export to various email clients, create groups, and sort through contacts alphabetically. Rackspace also allows you to sync your contacts with your mobile device and with Rackspace Email Plus.
 
 ### Calendar
 
-Rackspace Email provides the ability to manage your appointments and meetings through our Webmail interface. You have the ability to share your calendar, create personal calendars, import events and add shared calendars within your domain. Rackspace also allows you to sync your calendar events with your mobile device as well with Rackspace Email Plus.
+Rackspace Email allows you to manage your appointments and meetings through our webmail interface. You can share your calendar, create personal calendars, import events and add shared calendars within your domain. Rackspace also allows you to sync your calendar events with your mobile device as well with Rackspace Email Plus.
 
 ### Tasks
 
-Rackspace Email provides the ability to manage your tasks through our Webmail interface. You have the ability to create new tasks, manage your tasks, and create a task list.
+Rackspace Email provides the ability to create and manage tasks and create task lists through our Webmail interface. 
 
 ### Notes
 
-Rackspace Email provides the ability to create notes. You can sync your Notes with your mobile device as well with Rackspace Email Plus.
+Rackspace Email provides the ability to create notes, syncing your notes with your mobile device and with Rackspace Email Plus.
 
 ### Settings
 
-Rackspace Email provides various options for you to manage your email account. While in the Webmail interface, click the menu beside your email address in the top-right corner and select **Settings** to see a list of features and options available.
+Rackspace Email provides various options for you to manage your email account. While in the webmail interface, click the menu beside your email address in the top-right corner and select **Settings** to see a list of features and options available.
 
 #### General Settings: Email options
 
-- **Display Preferences** provides several options for you to display HTML emails, enable shortcuts, change your viewing pane and change the number of messages displayed in your reading pane.
+- **Display Preferences** provides several options for you to display HTML emails, enable shortcuts, change your viewing pane, and change the number of messages displayed in your reading pane.
 - **New Messages** provides the option to play an alert for the arrival of new messages and the option to choose how often to check for new messages.
 - **Trash Options** provides the option to move deleted email to the trash or immediately purge upon deletion.
 

--- a/content/rackspace-email/rackspace-webmail.md
+++ b/content/rackspace-email/rackspace-webmail.md
@@ -5,18 +5,17 @@ title: Rackspace Webmail overview
 type: article
 created_date: '2012-05-27'
 created_by: Rackspace Support
-last_modified_date: '2017-08-16'
-last_modified_by: Nate Archer
+last_modified_date: '2017-11-26'
+last_modified_by: Paige Warmker
 product: Rackspace Email
 product_url: rackspace-email
 ---
 
-Rackspace Email allows you to check and manage their email online
-through a Webmail interface. Webmail is a direct connection to your email without the need of additional software. Messages that are sent and received using Webmail will be waiting for you the next time you log into the portal. The Webmail portal provides most of the same functionality a mail client would offer, from sending and receiving email to setting up email signatures and even setting up email forwarding to your personal email accounts.
+Rackspace Email allows you to check and manage your email online through a Webmail interface. Webmail is a direct connection to your email without the need for additional software. Messages that are sent and received using Webmail will be waiting for you the next time you log into the portal. The Webmail portal provides most of the same functionality a mail client would offer, from sending and receiving email to setting up email signatures and even setting up email forwarding to your personal email accounts.
 
 ### Log in to Webmail
 
-To log in into Webmail, go to <https://apps.rackspace.com/>.
+To log in to Webmail, go to <https://apps.rackspace.com/>.
 
 When you log in, Rackspace allows several options:
 
@@ -25,30 +24,28 @@ When you log in, Rackspace allows several options:
 
 ### Contacts
 
-Rackspace Email allows you the ability to manage their contacts through our Webmail interface. Users have the ability add new contacts, import and export old contacts using a **.csv** file, export to various email clients, create groups, and sort through contacts alphabetically. Rackspace also allows you to sync your contacts with your mobile device as well with Rackspace Mobile Sync.
+Rackspace Email provides the ability to manage your contacts through our Webmail interface. You have the ability to add new contacts, import and export old contacts using a **.csv** file, export to various email clients, create groups, and sort through contacts alphabetically. Rackspace also allows you to sync your contacts with your mobile device as well with Rackspace Email Plus.
 
 ### Calendar
 
-Rackspace Email allows you the ability to manage their appointments and meetings through our Webmail interface. Users
-have the ability to share their calendar, create personal calendars, import events and add shared calendars within your domain. Rackspace also allows you to sync your calender events with your mobile device as well with Rackspace Mobile Sync.
+Rackspace Email provides the ability to manage your appointments and meetings through our Webmail interface. You have the ability to share your calendar, create personal calendars, import events and add shared calendars within your domain. Rackspace also allows you to sync your calendar events with your mobile device as well with Rackspace Email Plus.
 
 ### Tasks
 
-Rackspace Email allows users the ability to manage their tasks through our Webmail interface. Users have the ability to create
-new tasks, manage their tasks, and create a task list.
+Rackspace Email provides the ability to manage your tasks through our Webmail interface. You have the ability to create new tasks, manage your tasks, and create a task list.
 
 ### Notes
 
-Rackspace Email provides the ability to create notes. You can sync your Notes with your mobile device as well with Rackspace Mobile Sync.
+Rackspace Email provides the ability to create notes. You can sync your Notes with your mobile device as well with Rackspace Email Plus.
 
 ### Settings
 
-Rackspace Email provides various options for users to manage their email account. While in the Webmail interface, click the menu beside your email address in the top-right corner and select **Settings** to see a list of features and options available for users.
+Rackspace Email provides various options for you to manage your email account. While in the Webmail interface, click the menu beside your email address in the top-right corner and select **Settings** to see a list of features and options available.
 
 #### General Settings: Email options
 
-- **Display Preferences** provides several options for users to display HTML emails, enable shortcuts, changing your viewing pane and change the number of messages displayed in your reading pane.
-- **New Messages** provides the option to play an alert for new the arrival of new messages and the option to choose how often to check for new messages.
+- **Display Preferences** provides several options for you to display HTML emails, enable shortcuts, change your viewing pane and change the number of messages displayed in your reading pane.
+- **New Messages** provides the option to play an alert for the arrival of new messages and the option to choose how often to check for new messages.
 - **Trash Options** provides the option to move deleted email to the trash or immediately purge upon deletion.
 
 <img src="{% asset_path rackspace-email/rackspace-webmail/Webmail.png %}" alt="" />


### PR DESCRIPTION
Makes consistent use of "you" rather than "they" or "users", per the style guidelines. Also fixes a few other typos, and removes "Mobile Sync" references in favor of "Rackspace Email Plus" (since Mobile Sync is no longer offered as a standalone service, but instead is bundled into the Rackspace Email Plus product).