### PR TITLE
Remove HA Group Note for configs via portal

### DIFF
--- a/content/cloud-databases/managing-cloud-databases-configuration-groups-in-the-cloud-control-panel.md
+++ b/content/cloud-databases/managing-cloud-databases-configuration-groups-in-the-cloud-control-panel.md
@@ -23,8 +23,6 @@ configuration group.
 
 This article describes how to manage configurations using the Cloud Control Panel.
 
-**Note:** Applying configurations to Cloud Databases HA groups is not yet supported in the Cloud Control Panel. You can create the configuration group, but it must be applied via the API. The Cloud Databases Developer Guide has details on how to [attach configuration groups to HA groups via the API](https://developer.rackspace.com/docs/cloud-databases/v1/developer-guide/#attach-configuration-group-to-ha-instance).
-
 For details about configuration parameters, see the MySQL documentation 
 [5.1.4 Server System Variables](http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html).
 


### PR DESCRIPTION
**Note:** Applying configurations to Cloud Databases HA groups is not yet supported in the Cloud Control Panel. You can create the configuration group, but it must be applied via the API. The Cloud Databases Developer Guide has details on how to [attach configuration groups to HA groups via the API](https://developer.rackspace.com/docs/cloud-databases/v1/developer-guide/#attach-configuration-group-to-ha-instance).

This doesn't appear to be the case anymore as I have been able to add custom configurations to my own HA group and a customer HA group via the mycloud portal.

-DaPriest Watson
  