### PR TITLE
Fix deadlink

### DIFF
--- a/content/rackspace-monitoring/getting-started-with-rackspace-monitoring-cli.md
+++ b/content/rackspace-monitoring/getting-started-with-rackspace-monitoring-cli.md
@@ -218,4 +218,4 @@ your infrastructure.  For more information, be sure to consult the
 [Development Guide for Rackspace
 Monitoring](https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#developer-guide)
 as well as the [Rackspace Monitoring
-FAQ](/how-to/cloud-monitoring-faq).
+FAQ](/how-to/rackspace-monitoring-faq).


### PR DESCRIPTION
The link to the Rackspace Monitoring FAQ ended as a 404 to https://support.rackspace.com/how-to/rackspace-monitoring/-faq/, this is a 301 response from the url from https://support.rackspace.com/how-to/cloud-monitoring-faq/, that will also need to be fixed but I'm not aware of where the redirects are located.

The correct article is https://support.rackspace.com/how-to/rackspace-monitoring-faq/ and this should fix that.

