### PR TITLE
Add note regarding Windows tracert name

### DIFF
--- a/content/cloud-networks/common-network-troubleshooting-tools.md
+++ b/content/cloud-networks/common-network-troubleshooting-tools.md
@@ -56,6 +56,8 @@ If no packets are received, as shown in the following example, the network might
 
 Traceroute is a computer network diagnostic tool that displays the route (or path) of a network hop and measures transit delays of packets across an IP network. Traceroute is particularly useful for identifying network latency issues.
 
+**Note:** On Windows operating systems the `traceroute` command is named `tracert`. When performing a traceroute from your computer you should substitute the command name for the appropriate one for your system.
+
 Use the `traceroute` command followed by URL of the website or the IP address of the server that you want to test as shown in the following example:
 
     $ traceroute google.com


### PR DESCRIPTION
This clears up possibly confusion that might happen if a Window user tries to run `traceroute` directly.
```
C:\Users\0x91>traceroute
'traceroute' is not recognized as an internal or external command,
operable program or batch file.

C:\Users\0x91>tracert

Usage: tracert [-d] [-h maximum_hops] [-j host-list] [-w timeout]
               [-R] [-S srcaddr] [-4] [-6] target_name

Options:
    -d                 Do not resolve addresses to hostnames.
    -h maximum_hops    Maximum number of hops to search for target.
    -j host-list       Loose source route along host-list (IPv4-only).
    -w timeout         Wait timeout milliseconds for each reply.
    -R                 Trace round-trip path (IPv6-only).
    -S srcaddr         Source address to use (IPv6-only).
    -4                 Force using IPv4.
    -6                 Force using IPv6.
```