### PR TITLE
Fixing FAQ question

### DIFF
--- a/content/cloud-networks/cloud-networks-faq.md
+++ b/content/cloud-networks/cloud-networks-faq.md
@@ -173,8 +173,7 @@ the old one.
 
 Yes. Users can provision security groups via the neutron client.
 
-#### Is this functionality integrated with and available from the Cloud Control
-Panel?
+#### Is this functionality integrated with and available from the Cloud Control Panel?
 
 Yes, but only inbound PublicNet and ServiceNet security groups are currently
 available in the control panel. To access additional features, you can use


### PR DESCRIPTION
FAQ Question had a newline before the last word of the question
which would drop the end of the question into the answer
section.

