### PR TITLE
Update differences-between-rackspace-cdn-and-rackspace-cloud-files.md

### DIFF
--- a/content/rackspace-cdn/differences-between-rackspace-cdn-and-rackspace-cloud-files.md
+++ b/content/rackspace-cdn/differences-between-rackspace-cdn-and-rackspace-cloud-files.md
@@ -1,6 +1,6 @@
 ---
 permalink: differences-between-rackspace-cdn-and-rackspace-cloud-files/
-audit_date:
+audit_date: '2018-06-26
 title: Differences between Rackspace CDN and Rackspace Cloud Files
 type: article
 created_date: '2015-05-08'
@@ -13,19 +13,21 @@ product_url: rackspace-cdn
 
 Rackspace Cloud Files is storage service that enables users to store an
 unlimited number of files and to publish and distribute content behind a
-content delivery network (CDN). Following are some differences between
-Rackspace CDN and Cloud Files:
+content delivery network (CDN). Rackspace CDN is a service to manage your 
+CDN-enabled domains and the origins and assets associated with those domains. 
+
+Following are some differences between Rackspace CDN and Cloud Files:
 
 -   Users of Rackspace CDN specify the origins that host the content,
     and the CDN pulls the content from these origins. Origins can be
     dedicated servers, cloud servers, cloud load balancers, 
-    a Cloud Files container or servers hosted outside of Rackspace. 
-    Users of Cloud Files can enable CDN on a container, 
+    a Cloud Files container, or servers hosted outside of Rackspace. 
+    Users of Cloud Files can enable a CDN on a container, 
     distributing the contents of that container to the CDN's edge nodes. 
 -   Rackspace CDN has no limit on purges. Cloud Files limits the number
     of purges per account, per day to 25.
 -   Rackspace CDN does not yet support streaming video from Cloud Files
-    CDN-enabled containers or serving CDN-enabled content over SSL/TLS.
+    However, serving other CDN-enabled containers or serving CDN-enabled content over SSL/TLS is possible.
     Cloud Files supports streaming video from CDN-enabled containers as
     well as serving CDN-enabled content over SSL/TLS.
 
@@ -38,7 +40,7 @@ These, and other differences, are summarized in the following table:
 | Caching rules (TTL) | Customizable | Flat per Container |
 | Force Refresh Content | Purge (per file)<br />Invalidate (Simple RegEX) | Purge (per file)<br />Limit 25 per day |
 | Restrictions | HTTP Referrer, GeoLocation, IP Address | N/A |
-| Streaming | No Support Provided (HTML5 compatible) | Chunked encoded streaming and iOS streaming available |
+| Streaming | No support is provided, with exception to CDN-enabled content over SSL/TSL | Chunked encoded streaming and iOS streaming available |
 
 ### Additional resources
 

--- a/content/rackspace-cdn/differences-between-rackspace-cdn-and-rackspace-cloud-files.md
+++ b/content/rackspace-cdn/differences-between-rackspace-cdn-and-rackspace-cloud-files.md
@@ -18,11 +18,10 @@ Rackspace CDN and Cloud Files:
 
 -   Users of Rackspace CDN specify the origins that host the content,
     and the CDN pulls the content from these origins. Origins can be
-    dedicated servers, cloud servers, cloud load balancers, or even
-    servers hosted outside of Rackspace. Users of Cloud Files can
-    CDN-enable a container, thereby distributing the contents of that
-    container to the CDN's edge nodes. In Rackspace CDN, it is not yet
-    possible to specify a Cloud Files container as an origin.
+    dedicated servers, cloud servers, cloud load balancers, 
+    Cloud Files container or even servers hosted outside of Rackspace. 
+    Users of Cloud Files can CDN-enable a container, thereby 
+    distributing the contents of that container to the CDN's edge nodes. 
 -   Rackspace CDN has no limit on purges. Cloud Files limits the number
     of purges per account, per day to 25.
 -   Rackspace CDN does not yet support streaming video from Cloud Files

--- a/content/rackspace-cdn/differences-between-rackspace-cdn-and-rackspace-cloud-files.md
+++ b/content/rackspace-cdn/differences-between-rackspace-cdn-and-rackspace-cloud-files.md
@@ -5,8 +5,8 @@ title: Differences between Rackspace CDN and Rackspace Cloud Files
 type: article
 created_date: '2015-05-08'
 created_by: Rackspace Support
-last_modified_date: '2015-10-05'
-last_modified_by: Catherine Richardson
+last_modified_date: '2018-06-26'
+last_modified_by: Becky Geizner
 product: Rackspace CDN
 product_url: rackspace-cdn
 ---
@@ -19,8 +19,8 @@ Rackspace CDN and Cloud Files:
 -   Users of Rackspace CDN specify the origins that host the content,
     and the CDN pulls the content from these origins. Origins can be
     dedicated servers, cloud servers, cloud load balancers, 
-    Cloud Files container or even servers hosted outside of Rackspace. 
-    Users of Cloud Files can CDN-enable a container, thereby 
+    a Cloud Files container or servers hosted outside of Rackspace. 
+    Users of Cloud Files can enable CDN on a container, 
     distributing the contents of that container to the CDN's edge nodes. 
 -   Rackspace CDN has no limit on purges. Cloud Files limits the number
     of purges per account, per day to 25.


### PR DESCRIPTION
Modify the article to reflect that Cloud Files Containers can be used as an origin for Rackspace CDN.

