### PR TITLE
Rename manage Cloud Server articles to match parent.

### DIFF
--- a/content/cloud-servers/delete-a-server.md
+++ b/content/cloud-servers/delete-a-server.md
@@ -1,5 +1,5 @@
 ---
-permalink: deleting-a-server/
+permalink: delete-a-server/
 audit_date:
 title: Delete a server
 type: article

--- a/content/cloud-servers/delete-a-server.md
+++ b/content/cloud-servers/delete-a-server.md
@@ -1,11 +1,11 @@
 ---
-permalink: deleting-your-server/
+permalink: deleting-a-server/
 audit_date:
-title: Delete your server
+title: Delete a server
 type: article
 created_date: '2012-07-19'
 created_by: Rackspace Support
-last_modified_date: '2016-06-21'
+last_modified_date: '2017-07-02'
 last_modified_by: Stephanie Fillmon
 product: Cloud Servers
 product_url: cloud-servers

--- a/content/cloud-servers/reboot-a-server.md
+++ b/content/cloud-servers/reboot-a-server.md
@@ -1,11 +1,11 @@
 ---
-permalink: reboot-your-server/
+permalink: reboot-a-server/
 audit_date:
-title: Reboot Your Server
+title: Reboot a Server
 type: article
 created_date: '2012-07-19'
 created_by: Ari Liberman
-last_modified_date: '2017-01-04'
+last_modified_date: '2018-07-02'
 last_modified_by: Laura Santamaria
 product: Cloud Servers
 product_url: cloud-servers

--- a/content/cloud-servers/reset-a-server-password.md
+++ b/content/cloud-servers/reset-a-server-password.md
@@ -1,12 +1,12 @@
 ---
-permalink: reset-your-server-password/
+permalink: reset-a-server-password/
 audit_date:
-title: Reset Your Server Password
+title: Reset a server's password
 type: article
 created_date: '2012-07-19'
 created_by: Rackspace Support
-last_modified_date: '2016-09-12'
-last_modified_by: Kyle Laffoon
+last_modified_date: '2018-07-01'
+last_modified_by: Nate Archer
 product: Cloud Servers
 product_url: cloud-servers
 ---

--- a/content/cloud-servers/resize-standard-and-general-purpose-servers.md
+++ b/content/cloud-servers/resize-standard-and-general-purpose-servers.md
@@ -1,12 +1,12 @@
 ---
-permalink: managing-your-server-resizing-standard-and-general-purpose-servers/
+permalink: resize-standard-and-general-purpose-servers/
 audit_date:
-title: Manage your server - resizing standard and general purpose servers
+title: Resize standard and general purpose servers
 type: article
 created_date: '2012-07-19'
 created_by: Rackspace Support
-last_modified_date: '2016-07-07'
-last_modified_by: Stephanie
+last_modified_date: '2018-07-01'
+last_modified_by: Nate Archer
 product: Cloud Servers
 product_url: cloud-servers
 ---


### PR DESCRIPTION
- This PR is a part of my full audit of the "Manage a server" and "Manage your server" articles. Since I am retiring the "Manage your server" article, I have updated the articles linked to that one to match the title of their new parent article, "Manage a server".