### PR TITLE
Changing the example for Cloud DNS resource

### DIFF
--- a/content/cloud-orchestration/building-cloud-orchestration-templates.md
+++ b/content/cloud-orchestration/building-cloud-orchestration-templates.md
@@ -572,7 +572,7 @@ Use the following template to create a domain in Cloud DNS and create records. N
         properties:
           emailAddress: "admin@domain.com"
           name: domain.com
-          records: [ {"name": "domain.com", "data": 123.456.78.90 , "type": "A" }, {"name": "www.domain.com", "data": domain.com , "type": "CNAME" } ]
+          records: [ {"name": "domain.com", "data": 1.2.3.4 , "type": "A" }, {"name": "www.domain.com", "data": domain.com , "type": "CNAME" } ]
 
 
 ####  Create a cloud queue


### PR DESCRIPTION
the example contains an invalid IPv4 address, which won't validate.

