### PR TITLE
Update cloud-networks-faq.md

### DIFF
--- a/content/cloud-networks/cloud-networks-faq.md
+++ b/content/cloud-networks/cloud-networks-faq.md
@@ -172,7 +172,7 @@ the old one.
 Outbound security group rules can only be created using the API. See the section
 titled "Create Outbound Security Group Rule" in the community post below:
 
-[Managing Security Groups and Rules] (https://community.rackspace.com/general/f/general-discussion-forum/ 
+[Managing Security Groups and Rules](https://community.rackspace.com/general/f/general-discussion-forum/ 
 8568/managing-security-groups-and-rules)
 
 #### Will security groups be supported via the neutron client?

--- a/content/cloud-networks/cloud-networks-faq.md
+++ b/content/cloud-networks/cloud-networks-faq.md
@@ -169,6 +169,12 @@ A security group can't be added as a child of another security group. You also
 can't edit a security group rule - you must add a new security group to replace
 the old one.
 
+Outbound security group rules can only be created using the api. See the section
+titled "Create Outbound Security Group Rule" in the community post below:
+
+[Managing Security Groups and Rules] (https://community.rackspace.com/general/f/general-discussion-forum/ 
+8568/managing-security-groups-and-rules)
+
 #### Will security groups be supported via the neutron client?
 
 Yes. Users can provision security groups via the neutron client.

--- a/content/cloud-networks/cloud-networks-faq.md
+++ b/content/cloud-networks/cloud-networks-faq.md
@@ -169,7 +169,7 @@ A security group can't be added as a child of another security group. You also
 can't edit a security group rule - you must add a new security group to replace
 the old one.
 
-Outbound security group rules can only be created using the api. See the section
+Outbound security group rules can only be created using the API. See the section
 titled "Create Outbound Security Group Rule" in the community post below:
 
 [Managing Security Groups and Rules] (https://community.rackspace.com/general/f/general-discussion-forum/ 


### PR DESCRIPTION
Adding another limitation for creating outbound security group rules which is currently only available via the api. Customers will not be able to add outbound rules via the mycloud portal and the linked url referenced in the mycloud portal currently routes to the FAQ which doesn't go into any detail about the limitation.

