### PR TITLE
Adding exceptions

### DIFF
--- a/content/cloud-networks/cloud-servers-attaching-and-detaching-networks.md
+++ b/content/cloud-networks/cloud-servers-attaching-and-detaching-networks.md
@@ -11,8 +11,7 @@ product: Cloud Networks
 product_url: cloud-networks
 ---
 
-You can attach (add) or detach (disconnect) networks from existing Next
-Gen Cloud Servers by using the [Cloud Networks API](https://developer.rackspace.com/docs/cloud-networks/v2/developer-guide/)
+You can attach (add) or detach (disconnect) networks from Cloud Servers by using the [Cloud Networks API](https://developer.rackspace.com/docs/cloud-networks/v2/developer-guide/)
 or the [Cloud Control Panel](http://mycloud.rackspace.com).
 
 This article describes how to attach and detach networks by using the
@@ -20,6 +19,10 @@ Cloud Control Panel. Please be aware that if you attach networks to or
 detach them from a cloud server, you might experience a brief
 interruption, usually lasting less than a minute, in traffic hitting
 your cloud server while networking is reset on the server.
+
+### Exceptions (OnMetal and RackConnect v2)
+
+OnMetal servers cannot attach and detach networks. For OnMetal, you must specify all desired networks at initial build time. While you can attach and detach networks from RackConnect v2 servers (API only), these actions are unsupported and will break Internet connectivity on your RackConnect v2 servers.
 
 ### To Attach (Add) a Network:
 


### PR DESCRIPTION
OnMetal and RackConnect v2 servers can't attach and detach networks

