### PR TITLE
New URL for Pitchfork

### DIFF
--- a/content/cloud-images/transferring-images-between-regions-of-the-rackspace-open-cloud-with-pitchfork.md
+++ b/content/cloud-images/transferring-images-between-regions-of-the-rackspace-open-cloud-with-pitchfork.md
@@ -11,7 +11,7 @@ product: Cloud Images
 product_url: cloud-images
 ---
 
-This article describes how to transfer Rackspace Cloud Servers instance images between regions of the Rackspace Cloud by using [Pitchfork](https://pitchfork.cloudapi.co/). Pitchfork is an interactive Rackspace Cloud API application that simplifies working with the Rackspace Cloud APIs. Using a browser, you can execute any Rackspace API command for any Cloud product without the need to get on a command line or use another CLI tool.
+This article describes how to transfer Rackspace Cloud Servers instance images between regions of the Rackspace Cloud by using [Pitchfork](https://pitchfork.rax.io/). Pitchfork is an interactive Rackspace Cloud API application that simplifies working with the Rackspace Cloud APIs. Using a browser, you can execute any Rackspace API command for any Cloud product without the need to get on a command line or use another CLI tool.
 
 **Note:** The size of the exported virtual hard disk (VHD) must not be allowed to expand past 40 GB, which is the largest allowable disk size for imports. Thus, you will not be able to import any server image sourced from a server larger than 2 GB General Purpose or 1 GB Standard.
 
@@ -51,7 +51,7 @@ Additionally, we recommend using a third-party application called Cyberduck to d
 
 To transfer the image, use the following steps:
 
-1. Open a browser and go to [https://pitchfork.cloudapi.co/images/#export_task-images](https://pitchfork.cloudapi.co/images/#export_task-images).
+1. Open a browser and go to [https://pitchfork.rax.io/images/#export_task-images](https://pitchfork.rax.io/images/#export_task-images).
 
 2. To log in to Pitchfork, click the link at the upper-right side of the page and enter your Rackspace Cloud username and API key.
 
@@ -79,7 +79,7 @@ To transfer the image, use the following steps:
 
 8. After the image is uploaded to the import container, import the image to the destination region:
 
-   a. Go to [https://pitchfork.cloudapi.co/images/#import_task-images](https://pitchfork.cloudapi.co/images/#import_task-images).
+   a. Go to [https://pitchfork.rax.io/images/#import_task-images](https://pitchfork.rax.io/images/#import_task-images).
    
    b. In the **Region** list, select the region to which you are transferring the image.
    


### PR DESCRIPTION
changed pitchfork.cloudapi.co to new URL: pitchfork.rax.io

