### PR TITLE
Update DNS Record for pitchfork.cloudapi.co to pitchfork.rax.io

### DIFF
--- a/content/cloud-images/transferring-images-between-regions-of-the-rackspace-open-cloud-with-pitchfork.md
+++ b/content/cloud-images/transferring-images-between-regions-of-the-rackspace-open-cloud-with-pitchfork.md
@@ -11,7 +11,7 @@ product: Cloud Images
 product_url: cloud-images
 ---
 
-This article describes how to transfer Rackspace Cloud Servers instance images between regions of the Rackspace Cloud by using [Pitchfork](https://pitchfork.cloudapi.co/). Pitchfork is an interactive Rackspace Cloud API application that simplifies working with the Rackspace Cloud APIs. Using a browser, you can execute any Rackspace API command for any Cloud product without the need to get on a command line or use another CLI tool.
+This article describes how to transfer Rackspace Cloud Servers instance images between regions of the Rackspace Cloud by using [Pitchfork](https://pitchfork.rax.io/). Pitchfork is an interactive Rackspace Cloud API application that simplifies working with the Rackspace Cloud APIs. Using a browser, you can execute any Rackspace API command for any Cloud product without the need to get on a command line or use another CLI tool.
 
 **Note:** The size of the exported virtual hard disk (VHD) must not be allowed to expand past 40 GB, which is the largest allowable disk size for imports. Thus, you will not be able to import any server image sourced from a server larger than 2 GB General Purpose or 1 GB Standard.
 
@@ -51,7 +51,7 @@ Additionally, we recommend using a third-party application called Cyberduck to d
 
 To transfer the image, use the following steps:
 
-1. Open a browser and go to [https://pitchfork.cloudapi.co/images/#export_task-images](https://pitchfork.cloudapi.co/images/#export_task-images).
+1. Open a browser and go to [https://pitchfork.rax.io/images/#export_task-images](https://pitchfork.rax.io/images/#export_task-images).
 
 2. To log in to Pitchfork, click the link at the upper-right side of the page and enter your Rackspace Cloud username and API key.
 
@@ -79,7 +79,7 @@ To transfer the image, use the following steps:
 
 8. After the image is uploaded to the import container, import the image to the destination region:
 
-   a. Go to [https://pitchfork.cloudapi.co/images/#import_task-images](https://pitchfork.cloudapi.co/images/#import_task-images).
+   a. Go to [https://pitchfork.rax.io/images/#import_task-images](https://pitchfork.rax.io/images/#import_task-images).
    
    b. In the **Region** list, select the region to which you are transferring the image.
    

--- a/content/cloud-servers/upgrade-citrix-tools-for-windows-servers.md
+++ b/content/cloud-servers/upgrade-citrix-tools-for-windows-servers.md
@@ -101,7 +101,7 @@ The upgrade requires an active connection to the internet. Follow these steps to
 
 1. Access the non-production server's Java console through the [Cloud Control Panel](https://mycloud.rackspace.com/). On the Servers page, click the gear icon next to the server’s name and then select **Emergency Console**.
 
-If you are comfortable using cURL, please visit this [community article](https://community.rackspace.com/products/f/25/t/5933) to find instructions about generating the NoVNC console link. Otherwise, login to [Pitchfork](https://pitchfork.cloudapi.co/servers/#get_vnc_console-cloud_servers) with your Rackspace username and API key. Prior to sending the API call, be sure to change the console_type to, "novnc". The response will contain the URL to the console; simply copy and paste the link into a new browser tab. Note that these URLs expire after about 10 minutes, and if the console is not in use, the session will be disconnected.
+If you are comfortable using cURL, please visit this [community article](https://community.rackspace.com/products/f/25/t/5933) to find instructions about generating the NoVNC console link. Otherwise, login to [Pitchfork](https://pitchfork.rax.io/servers/#get_vnc_console-cloud_servers) with your Rackspace username and API key. Prior to sending the API call, be sure to change the console_type to, "novnc". The response will contain the URL to the console; simply copy and paste the link into a new browser tab. Note that these URLs expire after about 10 minutes, and if the console is not in use, the session will be disconnected.
 
 2. Start a command prompt as an administrator.
 
@@ -122,7 +122,7 @@ C:\rs-pkgs\xs-tools-6.5.0-20200\install.bat
 **Warning to RackConnect v2 Customers:** Manually resetting the network of a server via the API will re-enable the server's public interface, and possibly remove the default route to your RackConnect Gateway. We advise customers with a RackConnect configuration to reach out to Rackspace support for help if having network connectivity problems after an upgrade of the Citrix Tools.
 
 #### Performing a Network Reset
-To reset the server's network via the API, please login to [Pitchfork](https://pitchfork.cloudapi.co/servers/#reset_network-cloud_servers) with yourRackspace username and API key. Issue the, "Reset Network" call using the server UUID.
+To reset the server's network via the API, please login to [Pitchfork](https://pitchfork.rax.io/servers/#reset_network-cloud_servers) with yourRackspace username and API key. Issue the, "Reset Network" call using the server UUID.
 
 To reset the server's network by hand, find the directory C:\rs-pkgs\ where separate text files exist that contain the IP configuration, and routing information that was present before upgrading the Citrix Tools.
 


### PR DESCRIPTION
Retiring domain pitchfork.cloudapi.co, replaced by pitchfork.rax.io.