### PR TITLE
Fix typos of repeated consecutive 'the'

### DIFF
--- a/content/cloud-databases/manage-cloud-databases-ha-groups-in-the-cloud-control-panel.md
+++ b/content/cloud-databases/manage-cloud-databases-ha-groups-in-the-cloud-control-panel.md
@@ -25,7 +25,7 @@ Use the following steps to create a new HA instance group:
 
 2.  In the top navigation bar, click **Select a Product > Rackspace Cloud**.
 
-3.  From the the **Databases** menu, select **MySQL Instance** under **CREATE
+3.  From the **Databases** menu, select **MySQL Instance** under **CREATE
     RESOURCES**.
 
 4.  In the **Identity** section, provide a name for the instance and specify

--- a/content/cloud-files/set-up-a-static-website-with-cloud-files.md
+++ b/content/cloud-files/set-up-a-static-website-with-cloud-files.md
@@ -53,7 +53,7 @@ Now your static website content is uploaded to your Cloud Files
 containers. However, to access your static website, you need the CDN
 URL.
 
-1.  In the Cloud Control Panel, go the the Cloud Files/Containers list.
+1.  In the Cloud Control Panel, go to the Cloud Files/Containers list.
 
 2.  Click the gear icon next to the name of your container and select
     **View All Links**.

--- a/content/cloud-servers/installing-mysql-server-on-ubuntu.md
+++ b/content/cloud-servers/installing-mysql-server-on-ubuntu.md
@@ -65,7 +65,7 @@ command:
 There is more than one way to work with a MySQL server, but this article
 focuses on the most basic and compatible approach, the `mysql` shell.
 
-1. At the command prompt, run the following command to launch the the `mysql`
+1. At the command prompt, run the following command to launch the `mysql`
    shell and enter it as the root user:
 
        /usr/bin/mysql -u root -p

--- a/content/cloud-servers/keep-cloud-serves-up-to-date.md
+++ b/content/cloud-servers/keep-cloud-serves-up-to-date.md
@@ -111,7 +111,7 @@ updates are completed, select the check box under **Microsoft Update**.
 
 4. (Optional) Notifications can be set up so that the output of the yum updates is emailed to inform the user what updates completed and what updates failed. Use the arrow keys on the keyboard to move down to the section titled "emitters".  The `emit\_via` value should should be set to `stdio`. 
 
-5. Move your cursor to the the "email" section.
+5. Move your cursor to the "email" section.
 
 6. Update the configuration to change the `email\_to` field to the email you want the output you to be sent.
 

--- a/content/cloud-servers/linux-server-security-best-practices.md
+++ b/content/cloud-servers/linux-server-security-best-practices.md
@@ -353,7 +353,7 @@ information, see
 security standard nor will it fit every environment. Use this sample only to
 help you with syntax and ideas on how to use `iptables`.
 
-Following are the the default locations where `iptables` rulesets are saved on a given Linux
+Following are the default locations where `iptables` rulesets are saved on a given Linux
 distribution. Some distributions allow you to save elsewhere by using the
 `iptables-save` command.
 

--- a/content/cloud-servers/rackspace-cloud-essentials-checking-a-server-s-ssh-host-fingerprint-with-the-web-console.md
+++ b/content/cloud-servers/rackspace-cloud-essentials-checking-a-server-s-ssh-host-fingerprint-with-the-web-console.md
@@ -262,7 +262,7 @@ handy if you need to check the fingerprint again. It's a little
 inconvenience at the outset in return for a pretty comforting security
 check you can run through easily when you connect from a new machine.
 
-Next we are going to look at the the [basics of security in a Linux system](/how-to/basic-cloud-server-security),
+Next we are going to look at the [basics of security in a Linux system](/how-to/basic-cloud-server-security),
 adding to what we learned about SSH connections and host keys.
 
 **Next section:** [Basics of security in a Linux system](/how-to/basic-cloud-server-security)

--- a/content/cloud-servers/scheduled-images-faq.md
+++ b/content/cloud-servers/scheduled-images-faq.md
@@ -110,7 +110,7 @@ In order to operate the scheduled images service with minimal impact on
 on-demand snapshots and other network-intensive data transfers, the time
 a snapshot occurs may be changed at any time to optimize load.  We
 reserve the right to modify the time your image is made so that we can
-balance the the number of image creations in flight throughout the cloud
+balance the number of image creations in flight throughout the cloud
 and throughout the day.
 
 #### Will the image created\_at reflect the completion or start time?

--- a/content/cloud-servers/set-up-apache-virtual-hosts-on-ubuntu.md
+++ b/content/cloud-servers/set-up-apache-virtual-hosts-on-ubuntu.md
@@ -274,7 +274,7 @@ domain.com and domain.net point to the same content.
     ServerName domain.com
     ServerAlias www.domain.com
 
-**Note**: This is not a rewrite rule, but the the domains defined here
+**Note**: This is not a rewrite rule, but the domains defined here
 will serve the same content (assuming you have set the DNS to point to
 your Cloud Server IP).
 

--- a/content/cloud-servers/troubleshoot-a-downed-linux-cloud-server.md
+++ b/content/cloud-servers/troubleshoot-a-downed-linux-cloud-server.md
@@ -63,7 +63,7 @@ Use the following steps the check the downed server's console:
   - If you see a response, the server is responsive. Skip to the **Ping/Nmap IP Address** section.
 
   - If the console is not responding or displays errors such as being out of system
-    resources, go the the **Attempt Reboot** section.
+    resources, go to the **Attempt Reboot** section.
 
 
 ### Attempt Reboot

--- a/content/cloud-servers/troubleshoot-a-downed-windows-cloud-server.md
+++ b/content/cloud-servers/troubleshoot-a-downed-windows-cloud-server.md
@@ -63,7 +63,7 @@ Use the following steps the check the downed server's console:
   - If you see a response, the server is responsive. Skip to the **Ping/Nmap IP Address** section.
 
   - If the console is not responding or displays errors such as being out of
-    system resources, go the the **Attempt Reboot** section.
+    system resources, go to the **Attempt Reboot** section.
 
 
 ### Attempt Reboot

--- a/content/cloud-servers/understanding-logrotate-utility.md
+++ b/content/cloud-servers/understanding-logrotate-utility.md
@@ -171,7 +171,7 @@ particular log. The possible commands include:
 If a rotation interval is not specified the log will be rotated whenever
 logrotate runs (unless another condition like `size` has been set).
 
-If you want to use a time interval other than the the defined ones, you need
+If you want to use a time interval other than the defined ones, you need
 to use cron to create a separate configuration file. For example, if you want
 to rotate a particular log file hourly, you could create a file in
 `/etc/cron.hourly` (you might need to create that directory too) that would
@@ -246,7 +246,7 @@ log.
     endscript
 
 `>/dev/null` tells logrotate to pipe the command's output to nowhere. In this
-case, you don't need to view the the output if the application restarted
+case, you don't need to view the output if the application restarted
 correctly.
 
 The `postrotate` command tells logrotate that the script to run, starts on the

--- a/content/retired-articles/rescue-mode-on-windows-servers.md
+++ b/content/retired-articles/rescue-mode-on-windows-servers.md
@@ -130,7 +130,7 @@ loader can no longer find the boot disk. This is what causes the server crash.
 
         bcdedit /store d:\boot\bcd /set {ntldr} device partition=c:
 
-5. Run the following command again to verify the the output:
+5. Run the following command again to verify the output:
 
         bcdedit /store d:\boot\bcd
 

--- a/content/skype-for-business/set-up-dns-records-for-cloud-office-skype-for-business.md
+++ b/content/skype-for-business/set-up-dns-records-for-cloud-office-skype-for-business.md
@@ -37,7 +37,7 @@ To configure your hosted implementation of Microsoft Skype for Business formerly
 -   \_sip.\_tls.*example.com*
 -   \_sipfederationtls.\_tcp.*example.com*
 
-Because of the nature of our hosted environment, the domain listed for the the CNAME records will contain specific Skype for Business DNS records. Use our help tool for the specific DNS records for your domain. 
+Because of the nature of our hosted environment, the domain listed for the CNAME records will contain specific Skype for Business DNS records. Use our help tool for the specific DNS records for your domain. 
 
 After you log in with a mailbox that is enabled for Skype for Business, you can find the DNS settings through the [Help Tool](https://emailhelp.rackspace.com/) as shown in the following image.
 


### PR DESCRIPTION
The docs have some pages with repeated 'the' articles.
```bash
grep ' the the ' -irl *
```