### PR TITLE
Add configuration and examples to article

### DIFF
--- a/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
+++ b/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
@@ -11,6 +11,8 @@ product: Cloud Files
 product_url: cloud-files
 ---
 
+### Install Swiftly
+
 Swiftly is a client tool that you can use to upload objects to and
 download objects from your Cloud Files account. Swiftly manages the
 storage of large objects in Cloud Files. If you have a very large object
@@ -24,7 +26,7 @@ For more information about Swiftly, see the following sites:
 -   Swiftly documentation: <http://gholt.github.io/swiftly/>
 -   Swiftly source code: <https://github.com/gholt/swiftly>
 
-### Install Swiftly on Ubuntu
+#### Install Swiftly on Ubuntu
 
 These instructions were verified on a server built from a Rackspace
 Ubuntu 13.10 public image.
@@ -43,7 +45,7 @@ Invoke the following instructions from a bash shell on your server.
 
         sudo pip install swiftly
 
-### Install Swiftly on CentOS
+#### Install Swiftly on CentOS
 
 These instructions were verified on a server built from a Rackspace
 CentOS 6.5 public image.
@@ -210,7 +212,7 @@ The response displays similarly to the following list:
         .CDN_ACCESS_LOGS
         Books
         
-#### Get a list of containers
+#### Get a list of containers with details
 
 Run the following command to get a list of containers including detailed information:
 
@@ -239,7 +241,8 @@ prefix (case sensitive):
         
 #### Post new headers to an object
 
-Run the following command to post new headers to an object (supports multiple headers in a single command, separated out as shown):
+Run the following command to post new headers to an object (supports multiple headers 
+in a single command, separated out as shown):
 
         swiftly post -h "<headerName1>:<headerValue1>" -h "<headerName2>:<headerValue2>" <containerName>/<objectName>
         

--- a/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
+++ b/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
@@ -296,7 +296,7 @@ Run the following command to perform a bulk update:
 #### Bulk delete specified objects
 
 Run the following command to perform a bulk delete of only objects within a container 
-whose name beings with a certain prefix (caching the Identity token and limiting to 
+whose name begins with a certain prefix (caching the Identity token and limiting to 
 100 concurrent API calls):
 
         swiftly --cache-auth --eventlet --concurrency=100 for CONTAINER --prefix STARTINGTEXT --output-names do delete "<item>"

--- a/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
+++ b/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
@@ -1,12 +1,12 @@
 ---
 permalink: install-the-swiftly-client-for-cloud-files/
-node_id: 4030
+audit_date: '2019-02-28'
 title: Install the Swiftly client for Cloud Files
 type: article
 created_date: '2014-04-21'
 created_by: Cloud Images
-last_modified_date: '2016-04-18'
-last_modified_by: Stephanie Fillmon
+last_modified_date: '2019-02-28'
+last_modified_by: Regan Murley
 product: Cloud Files
 product_url: cloud-files
 ---
@@ -64,6 +64,7 @@ Invoke the following instructions from a bash shell on your server.
         sudo pip install swiftly
         
 ### Configure Swiftly for Rackspace Cloud Files
+
 Edit or create the file `~/.swiftly.conf`. By default, swiftly will use the configuration file in the same local directory where it is run, or you can define a file path while running swiftly commands using the `--conf=PATH` flag. Include the following contents in your `.swiftly.conf` file:
 
         [swiftly]
@@ -75,9 +76,12 @@ Edit or create the file `~/.swiftly.conf`. By default, swiftly will use the conf
 For the full list of options available in the `.swiftly.conf` file, see [the sample config file in the swiftly repo](https://github.com/gholt/swiftly/blob/master/swiftly.conf-sample).
 
 ### Install Eventlet (optional)
+
 Eventlet is an optional pip package that allows you to set a concurrency count when using swiftly. This is useful when performing bulk actions that are threaded, because the Cloud Files API has a limit of 100 concurrent write requests per container. 
 
-### Install Eventlet on Ubuntu
+#### Install Eventlet on Ubuntu
+
+Invoke the following instructions from a bash shell on your server.
 
 1. Install the Python developer library package using `apt-get`.
 
@@ -87,7 +91,9 @@ Eventlet is an optional pip package that allows you to set a concurrency count w
 
         sudo pip install eventlet
         
-### Install Eventlet on CentOS
+#### Install Eventlet on CentOS
+
+Invoke the following instructions from a bash shell on your server.
 
 1. Install the Python developer library package using `yum`.
 
@@ -101,7 +107,7 @@ Eventlet is an optional pip package that allows you to set a concurrency count w
 
 GNU Screen is a program that you can use to start a screen session. A
 screen session looks just like an ordinary shell except that you can
-"detach" a terminal from a screen session, and whatever commands you are
+*detach* a terminal from a screen session, and whatever commands you are
 running  continue running in the session. This functionality is useful
 when you start a long running process (such as a large object upload)
 from the command line. If your laptop battery dies, or your wireless
@@ -184,79 +190,113 @@ following command:
 
 ### Swiftly Example Commands
 
-Important Note: Swiftly allows for destructive actions to be run against 
-one or all containers on an account. Please use caution when performing 
-updates and deletes to cloud files objects, as these cannot be undone, 
-and test out your commands first against test containers wherever possible.
+**Important** Swiftly allows for destructive actions to be run against 
+one or all containers on an account. Use caution when performing updates 
+and deletes to cloud files objects, because these cannot be undone. 
+Test your commands against test containers wherever possible before
+running them in production.
 
-Get a list of containers for the configured account:
+Following are some common swiftly command examples.
+
+#### Get a list of containers
+
+Run the following command to get a list of containers for the configured account:
 
         swiftly get
         
-The response will be in a list:
+The response displays similarly to the following list:
 
         .ACCESS_LOGS
         .CDN_ACCESS_LOGS
         Books
         
-Get a list of containers including detailed information:
+#### Get a list of containers
+
+Run the following command to get a list of containers including detailed information:
 
         swiftly get --raw
         
-The response will be in json format:
+The response displays in json format:
 
         [{"count": 103, "bytes": 22296, "name": ".ACCESS_LOGS"}, 
         {"count": 126, "bytes": 32708, "name": ".CDN_ACCESS_LOGS"}, 
         {"count": 417, "bytes": 1177376576, "name": "Books"}]
         
-Get a list of objects in a container:
+#### Get a list of objects in a container
+
+Run the following command to get a list of objects in a container:
 
         swiftly get <containerName>
         
-Get containers or objects that match a beginning prefix (case sensitive):
+#### Get containers or objects that match a beginning prefix (case sensitive)
+
+Run the following command to get containers or objects that match a beginning 
+prefix (case sensitive):
 
         swiftly get --prefix <startingText>
         
         swiftly get <containerName> --prefix <startingText>
         
-Post new headers to an object (supports multiple headers in a single 
-command, separated out as shown):
+#### Post new headers to an object
+
+Run the following command to post new headers to an object (supports multiple headers in a single command, separated out as shown):
 
         swiftly post -h "<headerName1>:<headerValue1>" -h "<headerName2>:<headerValue2>" <containerName>/<objectName>
         
-Upload an object (This example will upload the local directory file 
-`somefile.png` and rename it to `newfilename.png` in the specified 
-container, placing the object into the pseudo directory `/images/`):
+#### Upload an object 
+
+This example uploads the local directory file **somefile.png** and renames it to 
+**newfilename.png** in the specified container and places the object into the pseudo 
+directory **/images/**).
+
+Run the following command to upload an object:
 
         swiftly put -i ~/somefile.png <containerName>/images/newfilename.png
         
-Delete an object, or delete an object within a pseudo directory:
+#### Delete an object
+
+Run the following command to delete an object, or delete an object within a pseudo directory:
 
         swiftly delete <containerName>/somefile.png
         swiftly delete <containerName>/images/newfilename.png
         
-Delete all objects within a container, then delete the container:
+#### Delete all objects within a container and delete the container
+
+Run the following command to delete all objects within a container and delete the container:
 
         swiftly delete <containerName> --until-empty --recursive
         
-Bulk update all files in a container to add the Header "HEADERNAME" 
-with a value of "HEADERVALUE". Note that swiftly for/do commands contain 
-literal `<` and `>` characters, include the exact text `<item>` in 
-the examples shown here. For best practices on for/do commands, `--cache-auth` 
+#### Bulk update
+        
+This command performs a bulk update all files in a container to add the Header **HEADERNAME** 
+with a value of **HEADERVALUE**. Note that swiftly for/do commands contain 
+literal open and close angle bracket characters (`<` and `>`), such as `<item>` in 
+the examples shown here. The angle brackets are part of the command not placeholders 
+for variable content. 
+
+As a best practice with for/do commands, `--cache-auth` 
 is set to temporarily store the authentication token rather than make repeated 
-calls to the Cloud Identity API, and `--concurrency` is limited to 100 maximum 
+calls to the Identity API, and `--concurrency` is limited to 100 maximum 
 api calls to Cloud Files:
+
+Run the following command to perform a bulk update:
 
         swiftly --cache-auth --eventlet --concurrency=100 for CONTAINER do post -H "HEADERNAME:HEADERVALUE" "<item>"
 
-Bulk delete only objects within a container whose name beings with a certain 
-prefix (caching the identity token and limiting to 100 concurrent API calls):
+#### Bulk delete specified objects
+
+Run the following command to perform a bulk delete of only objects within a container 
+whose name beings with a certain prefix (caching the identity token and limiting to 
+100 concurrent API calls):
 
         swiftly --cache-auth --eventlet --concurrency=100 for CONTAINER --prefix STARTINGTEXT --output-names do delete "<item>"
 
+#### Bulk delete specified containers
 
-Bulk delete only containers whose name begins with a certain prefix (caching 
-the identity token and limiting to 100 concurrent API calls):
+Run the following command to perform  Bulk delete OF only containers whose name 
+begins with a certain prefix (caching the identity token and limiting to 100 
+concurrent API calls):
+
 
         swiftly --cache-auth --eventlet --concurrency=100 for "" --prefix STARTINGTEXT --output-names do delete "<item>" --recursive --until-empty
         

--- a/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
+++ b/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
@@ -13,46 +13,46 @@ product_url: cloud-files
 
 ### Install Swiftly
 
-Swiftly is a client tool that you can use to upload objects to and
-download objects from your Cloud Files account. Swiftly manages the
+Swiftly is a client tool that you can use to upload objects to and download 
+objects from your Rackspace Cloud Files account. Swiftly manages the
 storage of large objects in Cloud Files. If you have a very large object
 (such as a virtual disk image file), Swiftly splits the file into
 smaller segments and then creates the large object manifest for you.
 
 For more information about Swiftly, see the following sites:
 
--   The Python package index page:
+-   The Python&reg; package index page:
     <https://pypi.python.org/pypi/swiftly/2.02>
 -   Swiftly documentation: <http://gholt.github.io/swiftly/>
 -   Swiftly source code: <https://github.com/gholt/swiftly>
 
 #### Install Swiftly on Ubuntu
 
-These instructions were verified on a server built from a Rackspace
-Ubuntu 13.10 public image.
+These instructions were built by Rackspace on an Ubuntu&reg; 13.10 public 
+image.
 
-Invoke the following instructions from a bash shell on your server.
+Use the following instructions from a Bash shell on your server:
 
-1.  Update the apt-get database.
+1.  Update the `apt-get` database.
 
         sudo apt-get update
 
-2.  Install the Python installer, pip, using `apt-get`.
+2.  Install the Python installer, `pip`, by using `apt-get`.
 
         sudo apt-get install python-pip
 
-3.  Install Swiftly using `pip`.
+3.  Install Swiftly by using `pip`.
 
         sudo pip install swiftly
 
 #### Install Swiftly on CentOS
 
-These instructions were verified on a server built from a Rackspace
-CentOS 6.5 public image.
+These instructions were verified by Rackspace on a CentOS&reg; 6.5 public 
+image.
 
-Invoke the following instructions from a bash shell on your server.
+Use the following instructions from a Bash shell on your server:
 
-1.  Install the Python installer, pip, using `yum`.
+1.  Install the Python installer, `pip`, by using `yum`.
 
         sudo yum install python-pip
 
@@ -61,13 +61,16 @@ Invoke the following instructions from a bash shell on your server.
     EPEL repository on your system, see [Install EPEL and additional repositories on CentOS and Red Hat](/how-to/install-epel-and-additional-repositories-on-centos-and-red-hat).
     When EPEL is enabled, run the `install` command for pip again.
 
-2.  Install swiftly using `pip`.
+2.  Install Swiftly by using `pip`.
 
         sudo pip install swiftly
         
-### Configure Swiftly for Rackspace Cloud Files
+### Configure Swiftly for Cloud Files
 
-Edit or create the file `~/.swiftly.conf`. By default, swiftly will use the configuration file in the same local directory where it is run, or you can define a file path while running swiftly commands using the `--conf=PATH` flag. Include the following contents in your `.swiftly.conf` file:
+Edit or create the file `~/.swiftly.conf`. By default, Swiftly uses the configuration file 
+in the same local directory where it is run, or you can define a file path while running 
+Swiftly commands by using the `--conf=PATH` flag. Include the following contents in your 
+**.swiftly.conf** file:
 
         [swiftly]
         auth_user = <yourUserName>
@@ -75,79 +78,84 @@ Edit or create the file `~/.swiftly.conf`. By default, swiftly will use the conf
         auth_url = https://identity.api.rackspacecloud.com/v2.0
         region = <datacenter>
 
-For the full list of options available in the `.swiftly.conf` file, see [the sample config file in the swiftly repo](https://github.com/gholt/swiftly/blob/master/swiftly.conf-sample).
+For the full list of options available in the **.swiftly.conf** file, see 
+[the sample config file in the Swiftly repo](https://github.com/gholt/swiftly/blob/master/swiftly.conf-sample).
 
-### Install Eventlet (optional)
+### Install Eventlet (*optional*)
 
-Eventlet is an optional pip package that allows you to set a concurrency count when using swiftly. This is useful when performing bulk actions that are threaded, because the Cloud Files API has a limit of 100 concurrent write requests per container. 
+Eventlet is an optional `pip` package that allows you to set a concurrency count when using 
+Swiftly. This count is useful when performing bulk actions that are threaded because the Cloud 
+Files application programming interface (API) has a limit of 100 concurrent write requests 
+per container. 
 
 #### Install Eventlet on Ubuntu
 
-Invoke the following instructions from a bash shell on your server.
+Use the following instructions from a Bash shell on your server:
 
-1. Install the Python developer library package using `apt-get`.
+1. Install the Python developer library package by using `apt-get`.
 
         sudo apt-get python-dev
 
-2. Install Eventlet using `pip`.
+2. Install Eventlet by using `pip`.
 
         sudo pip install eventlet
         
 #### Install Eventlet on CentOS
 
-Invoke the following instructions from a bash shell on your server.
+Use the following instructions from a Bash shell on your server:
 
-1. Install the Python developer library package using `yum`.
+1. Install the Python developer library package by using `yum`.
 
         sudo yum install python-devel
 
-2. Install Eventlet using `pip`.
+2. Install Eventlet by using `pip`.
 
         sudo pip install eventlet
 
-### Install GNU Screen (optional)
+### Install GNU Screen (*optional*)
 
-GNU Screen is a program that you can use to start a screen session. A
-screen session looks just like an ordinary shell except that you can
-*detach* a terminal from a screen session, and whatever commands you are
+GNU Screen is a program that you can use to start a Screen session. A
+Screen session looks just like an ordinary shell except that you can
+*detach* a terminal from a Screen session, and whatever commands you are
 running  continue running in the session. This functionality is useful
 when you start a long running process (such as a large object upload)
 from the command line. If your laptop battery dies, or your wireless
 connection is lost, or you are otherwise disconnected, the process
-continue to run in your screen session.
+continues to run in your Screen session.
 
-#### Install screen in Ubuntu
+#### Install Screen in Ubuntu
 
-Invoke the following command from a bash shell:
+Use the following instructions from a Bash shell on your server to install 
+Screen in Ubuntu:
 
     sudo apt-get install screen
 
-#### Installing screen in CentOS
+#### Installing Screen in CentOS
 
-Invoke the following command from a bash shell:
+Invoke the following instructions from a Bash shell on your server to install 
+Screen in CentOS:
 
     sudo yum install screen
 
-#### Get started with the screen program
+#### Get started with Screen
 
-To start the screen program, run the following command. The `-s`
+To start Screen, run the following command. The `-s`
 option tells the program what shell to use. The `-S` option provides a
-name for the session, which is helpful if you will have several screen
+name for the session, which is helpful if you have several Screen
 sessions running at the same time.
 
     screen -s /bin/bash -S display-Name-For-Screen
 
-After you start the screen program, you can enter regular bash
-commands. Screen commands, that is, commands requesting screen to do
-something, are escaped with `Control-a` (or `C-a`) . Some screen
-commands are single character. For example, to detach from screen, you
-type the following command:
+After you start Screen, you can enter regular Bash commands. Screen commands, 
+that is, commands requesting Screen to do something, are escaped with `Control-a` 
+(or `C-a`) . Some Screen commands are single character. For example, to detach from 
+Screen, type the following command:
 
     C-a d
 
-Other screen commands are longer. To use these, you first type
+Other Screen commands are longer. To use these, you first type
 `C-a:` and then you type the rest of the command in the status line
-of the screen window. For example, you can log screen's output to a file
+of the Screen window. For example, you can log Screen's output to a file
 so that you can go back and review it later by typing the following
 command:
 
@@ -156,27 +164,27 @@ command:
     C-a : logfile name-of-log-file
     C-a : log
 
-The first command sets the name of the file in which the log will be
-recorded. The second command toggles logging on and off; because this is
-the first time you typed it, it will turn logging on.
+The first command sets the name of the file in which the log is
+recorded. The second command toggles logging on and off. Because this is
+the first time you typed it, it turns logging on.
 
-We encourage to create a log of screen output so that you'll have a
-record of everything that happened while you were detached from screen.
+We encourage you to create a log of Screen output so that you have a
+record of everything that happened while you were detached from Screen.
 
-To exit screen, just type `Control-d` (without prefacing it with
+To exit Screen, just type `Control-d` (without prefacing it with
 `Control-a`).
 
-You can learn more about screen by visiting
+You can learn more about Screen by visiting
 <http://www.gnu.org/software/screen/manual/screen.html>.
 
-#### Reattach to a running screen session
+#### Reattach to a running Screen session
 
-You can get a list of what screen sessions you currently have running by
-invoking this command from a bash shell:
+You can get a list of what Screen sessions you currently have running by
+invoking this command from a Bash shell:
 
     screen -list
 
-Your response will look something like the following:
+Your response looks something like the following output:
 
     There are screens on:
         3064.some-other-stuff   (Detached)
@@ -184,21 +192,21 @@ Your response will look something like the following:
         3073.even-more-stuff    (Detached)
     3 Sockets in /var/run/screen/S-root.
 
-To reattach to the screen session named large-obj-transfer, for example,
-you note the session number (in this example, 3004) and then use the
+To reattach to the Screen session named **large-obj-transfer**, for example,
+note the session number (in this example, `3004`) and then use the
 following command:
 
     screen -r 3004
 
-### Swiftly Example Commands
+### Swiftly example commands
 
-**Important** Swiftly allows for destructive actions to be run against 
+**Important:** Swiftly allows destructive actions to run against 
 one or all containers on an account. Use caution when performing updates 
-and deletes to cloud files objects, because these cannot be undone. 
+and deletes to Cloud Files objects because these cannot be undone. 
 Test your commands against test containers wherever possible before
 running them in production.
 
-Following are some common swiftly command examples.
+Following are some common Swiftly command examples.
 
 #### Get a list of containers
 
@@ -206,7 +214,7 @@ Run the following command to get a list of containers for the configured account
 
         swiftly get
         
-The response displays similarly to the following list:
+The response is similar to the following list:
 
         .ACCESS_LOGS
         .CDN_ACCESS_LOGS
@@ -218,7 +226,7 @@ Run the following command to get a list of containers including detailed informa
 
         swiftly get --raw
         
-The response displays in json format:
+The response displays in JavaScript&reg; Object Notation (JSON)  format:
 
         [{"count": 103, "bytes": 22296, "name": ".ACCESS_LOGS"}, 
         {"count": 126, "bytes": 32708, "name": ".CDN_ACCESS_LOGS"}, 
@@ -230,7 +238,7 @@ Run the following command to get a list of objects in a container:
 
         swiftly get <containerName>
         
-#### Get containers or objects that match a beginning prefix (case sensitive)
+#### Get containers or objects that match a beginning prefix
 
 Run the following command to get containers or objects that match a beginning 
 prefix (case sensitive):
@@ -242,14 +250,14 @@ prefix (case sensitive):
 #### Post new headers to an object
 
 Run the following command to post new headers to an object (supports multiple headers 
-in a single command, separated out as shown):
+in a single command, separated as shown):
 
         swiftly post -h "<headerName1>:<headerValue1>" -h "<headerName2>:<headerValue2>" <containerName>/<objectName>
         
 #### Upload an object 
 
-This example uploads the local directory file **somefile.png** and renames it to 
-**newfilename.png** in the specified container and places the object into the pseudo 
+The following example uploads the local directory file **somefile.png**, renames it to 
+**newfilename.png** in the specified container, and places the object into the pseudo 
 directory **/images/**).
 
 Run the following command to upload an object:
@@ -271,16 +279,15 @@ Run the following command to delete all objects within a container and delete th
         
 #### Bulk update
         
-This command performs a bulk update all files in a container to add the Header **HEADERNAME** 
-with a value of **HEADERVALUE**. Note that swiftly for/do commands contain 
+This command performs a bulk update of all files in a container to add the header **HEADERNAME** 
+with a value of **HEADERVALUE**. Note that Swiftly `for/do` commands contain 
 literal open and close angle bracket characters (`<` and `>`), such as `<item>` in 
-the examples shown here. The angle brackets are part of the command not placeholders 
+the examples shown here. The angle brackets are part of the command, not placeholders 
 for variable content. 
 
-As a best practice with for/do commands, `--cache-auth` 
-is set to temporarily store the authentication token rather than make repeated 
-calls to the Identity API, and `--concurrency` is limited to 100 maximum 
-api calls to Cloud Files:
+As a best practice with `for/do` commands, `--cache-auth` is set to temporarily store 
+the authentication token rather than make repeated calls to the Identity API, and 
+`--concurrency` is limited to 100 maximum API calls to Cloud Files:
 
 Run the following command to perform a bulk update:
 
@@ -289,15 +296,15 @@ Run the following command to perform a bulk update:
 #### Bulk delete specified objects
 
 Run the following command to perform a bulk delete of only objects within a container 
-whose name beings with a certain prefix (caching the identity token and limiting to 
+whose name beings with a certain prefix (caching the Identity token and limiting to 
 100 concurrent API calls):
 
         swiftly --cache-auth --eventlet --concurrency=100 for CONTAINER --prefix STARTINGTEXT --output-names do delete "<item>"
 
 #### Bulk delete specified containers
 
-Run the following command to perform  Bulk delete OF only containers whose name 
-begins with a certain prefix (caching the identity token and limiting to 100 
+Run the following command to perform a bulk delete of only containers whose name 
+begins with a certain prefix (caching the Identity token and limiting to 100 
 concurrent API calls):
 
 

--- a/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
+++ b/content/cloud-files/install-the-swiftly-client-for-cloud-files.md
@@ -302,4 +302,3 @@ concurrent API calls):
 
 
         swiftly --cache-auth --eventlet --concurrency=100 for "" --prefix STARTINGTEXT --output-names do delete "<item>" --recursive --until-empty
-        


### PR DESCRIPTION
Some examples in this article do not follow the style guide for code placeholders because the swiftly commands contain the literal text "<item>" which is very similar.