### PR TITLE
Ubuntu LTS Updates

### DIFF
--- a/content/dedicated-hosting/linux-spheres-of-support-for-dedicated-and-managed-ops.md
+++ b/content/dedicated-hosting/linux-spheres-of-support-for-dedicated-and-managed-ops.md
@@ -23,13 +23,11 @@ The following operating systems are supported for both Dedicated and Managed Ope
 - Red Hat Enterprise Linux 6
 - Ubuntu&reg; 18.04 LTS (Bionic Beaver)
 - Ubuntu 16.04 LTS (Xenial Xerus)
-- Ubuntu 14.04 LTS (Trusty Tahr)
 
 The following operating systems are supported only for Managed Operations:
 
 - Debian&reg; 9 (Stretch)
 - Debian 8 (Jessie)
-- Ubuntu 18.04 LTS (Bionic Beaver)
 
 **Note**: Rackspace makes every effort to align our support dates for operating systems with the manufacturer's support dates. If a manufacturer decides to shorten the support life of an operating system, Rackspace might be forced to end support sooner than originally anticipated. For full details on support life, see the [Rackspace EOL Terms](https://www.rackspace.com/information/legal/eolterms).
 


### PR DESCRIPTION
Removed Ubuntu 14.04 LTS as that is now End of Life
Removed duplicate listing of Ubuntu 18.04 LTS - the bottom one in "Managed Operations", since listing at the top will include Managed Operations

