### PR TITLE
Grammar: change "is" to "are"

### DIFF
--- a/content/rackspace-email/rackspace-directory-sync-install-and-configure.md
+++ b/content/rackspace-email/rackspace-directory-sync-install-and-configure.md
@@ -5,15 +5,15 @@ title: 'Rackspace Directory Sync: Install and configure'
 type: article
 created_date: '2013-04-25'
 created_by: Kevin Richey
-last_modified_date: '2018-11-20'
-last_modified_by: Stephanie Fillmon
+last_modified_date: '2019-08-15'
+last_modified_by: Cat Lookabaugh
 product: Rackspace Email
 product_url: rackspace-email
 ---
 
 Rackspace Directory Sync enables Rackspace Hosted Email customers to
 synchronize their local Microsoft&reg; Active Directory objects and user
-passwords with Rackspace Hosted Email in real time. This article describes
+passwords with Rackspace Hosted Email in real-time. This article describes
 how to install and configure Rackspace Directory Sync.
 
 ### System requirements
@@ -64,7 +64,7 @@ Enable the following ports on the Directory Sync server:
 Communication between Directory Sync and Rackspace is secured through
 HTTPS. Communications between the Active Directory password hook and
 Directory Sync are secured with Microsoft Windows Communication
-Foundation (WCF) transport security which uses Windows authentication
+Foundation (WCF) transport security, which uses Windows authentication
 and encryption.
 
 #### Installation files
@@ -122,7 +122,7 @@ the DC.
 click **No** to manually restart it later. You must restart for the changes
 to take effect. If you restart now, the installation wizard continues.
 
-When installation is complete, the web UI for validation and synchronization
+When the installation is complete, the web UI for validation and synchronization
 automatically opens. A shortcut to the web UI is created on both the Start
 menu and on the desktop.
 
@@ -183,7 +183,7 @@ Directory Sync by performing the following steps:
         click the **Sync History** tab and then click the **Sync
         Now** button.
 
-**Note:** The Directory Sync services never makes changes to the
+**Note:** The Directory Sync services never make changes to the
 directory. All access is read-only.
 
 ### Synchronize users and groups
@@ -203,7 +203,7 @@ the Directory Sync UI and is where Directory Sync is configured.
 
 If you have multiple DCs to manage the Active Directory, you must
 install the Password Handler on all DCs except the primary DC (the
-Password Handler is installed during initial setup). Normally, password
+Password Handler is installed during the initial setup). Normally, password
 changes in a network occur locally and then are replicated to the other
 DCs. Directory Sync is unable to see those password changes after
 replication because of encryption. To ensure that password changes are
@@ -237,7 +237,7 @@ Repeat the following steps for each additional DC in the
 Active Directory forest.
 
 **Important:** You must restart each DC to complete this
-process. Consider performing these steps during off hours
+process. Consider performing these steps during off-hours
 
 1. Copy the **.msi** file to the secondary DC.
 2. Double-click the installation file and click **Next** on the welcome

--- a/content/rackspace-email/rackspace-directory-sync-install-and-configure.md
+++ b/content/rackspace-email/rackspace-directory-sync-install-and-configure.md
@@ -13,7 +13,7 @@ product_url: rackspace-email
 
 Rackspace Directory Sync enables Rackspace Hosted Email customers to
 synchronize their local Microsoft&reg; Active Directory objects and user
-passwords with Rackspace Hosted Email in real-time. This article describes
+passwords with Rackspace Hosted Email in real time. This article describes
 how to install and configure Rackspace Directory Sync.
 
 ### System requirements
@@ -118,7 +118,7 @@ the DC.
 2. Open the file and follow the prompts for installing the Directory
    Sync service.
 
-**Note**: When prompted click **Yes** to restart your system now, or
+**Note**: When prompted, click **Yes** to restart your system now or
 click **No** to manually restart it later. You must restart for the changes
 to take effect. If you restart now, the installation wizard continues.
 
@@ -134,7 +134,7 @@ any errors occur when the service is starting, view the event log for
 more information about the error.
 
 **Note:** We recommend creating new security groups in Active Directory
-that will manage the list of synchronized users for each hosted service.
+that manage the list of synchronized users for each hosted service.
 For example, if you are synchronizing Exchange users, create a new
 security group in Active Directory as Rackspace Exchange or Rackspace
 Hosted Exchange.
@@ -152,7 +152,7 @@ Directory Sync by performing the following steps:
     **Register**.
     - Customers who logged in to the [MyRackspace Portal](https://login.rackspace.com)
         will automatically create an admin ID through the MyRackspace
-        Portal before download
+        Portal before download.
     - Customers who logged in to the [Cloud Office Control Panel](https://cp.rackspace.com)
         should create a new admin ID dedicated to the
         sync service.
@@ -180,8 +180,7 @@ Directory Sync by performing the following steps:
         last synchronization. This synchronization type runs
         automatically every 5 minutes by default but can also be
         performed manually. To manually run a delta synchronization,
-        click the **Sync History** tab and then click the **Sync
-        Now** button.
+        click the **Sync History** tab and then click the **Sync Now** button.
 
 **Note:** The Directory Sync services never make changes to the
 directory. All access is read-only.
@@ -227,8 +226,8 @@ the **Directory Sync Password Handler Install** folder was created on
 the desktop. Use the installer in this folder to synchronize your users'
 passwords across multiple DCs.
 
-**Note:** The **.msi** file within the folder should be installed on the
-secondary DCs only.
+**Note:** The **.msi** file within the folder should be installed only on the
+secondary DCs.
 
 <img src="{% asset_path rackspace-email/rackspace-directory-sync-install-and-configure/Installer8_0.png %}" width="563" height="393" />
 
@@ -237,11 +236,10 @@ Repeat the following steps for each additional DC in the
 Active Directory forest.
 
 **Important:** You must restart each DC to complete this
-process. Consider performing these steps during off-hours
+process. Consider performing these steps during off-hours.
 
 1. Copy the **.msi** file to the secondary DC.
-2. Double-click the installation file and click **Next** on the welcome
-    page of the wizard.
+2. Double-click the installation file and click **Next** on the welcome page of the wizard.
 3. On the next page, click **Install**.
 4. After the restart, click **Finish**.
 

--- a/content/rackspace-email/rackspace-directory-sync-install-and-configure.md
+++ b/content/rackspace-email/rackspace-directory-sync-install-and-configure.md
@@ -63,7 +63,7 @@ Enable the following ports on the Directory Sync server:
 
 Communication between Directory Sync and Rackspace is secured through
 HTTPS. Communications between the Active Directory password hook and
-Directory Sync is secured with Microsoft Windows Communication
+Directory Sync are secured with Microsoft Windows Communication
 Foundation (WCF) transport security which uses Windows authentication
 and encryption.
 


### PR DESCRIPTION
Changed "Communications between the Active Directory password hook and
Directory Sync **_is_** secured with Microsoft Windows Communication
Foundation (WCF).." to "Communications between the Active Directory password hook and
Directory Sync **_are_** secured with Microsoft Windows Communication
Foundation (WCF).." since the subject of the sentence, "Communications", is plural.

