### PR TITLE
Update EL7 cloud-init issue docs with nova-agent ref + cloud network warning 

### DIFF
--- a/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
+++ b/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
@@ -5,7 +5,7 @@ title: Network configuration for eth0 changed to DHCP after upgrading RHEL/CentO
 type: article
 created_date: '2019-01-18'
 created_by: Rackspace Community
-last_modified_date: '2019-02-18'
+last_modified_date: '2019-11-15'
 last_modified_by: Erik Wilson
 product: Cloud Servers
 product_url: cloud-servers
@@ -50,11 +50,26 @@ This command stops the **cloud-init** application from deleting your `eth0` conf
 
 If you have rebooted and networking is down, complete the following steps:
 
-1. Add a Cloud Network to the server or reset the network application programming interface (API) call.
+1. Check that **nova-agent** is running on the server as it is required to automatically load the networking configuration.
 
-   You cannot reset the network API call through the Rackspace MyCloud portal. You must use the API. The easiest way to use the API is with the unofficial graphical user interface (GUI) API tool, [Pitchfork](https://pitchfork.rax.io/servers/#reset_network-cloud_servers).
+         systemctl is-active nova-agent
+         
+   If the agent is not running, make sure to start it and set "active" on-boot.
+         
+         systemctl start nova-agent
+         systemctl enable nova-agent 
 
-2. After you recover networking, run the following command or rebooting continues to break networking:
+2. Trigger the **nova-agent** to reload the network configuration by either adding a Cloud Network to the server, sending an application programming interface (API) call to "reset network", or trigger the reset locally on the server.
+ 
+   If adding a new Cloud Network, make sure when you remove it that you do not remove/disconnect the existing Public or Private networks, otherwise you may lose your IP address.
+
+   You cannot trigger the "reset network" [API call](https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#reset-network-for-server) through the Rackspace MyCloud portal. You must use the API. The easiest way to use the API is with the unofficial graphical user interface (GUI) API tool, [Pitchfork](https://pitchfork.rax.io/servers/#reset_network-cloud_servers).
+   
+   To trigger the reset on the server itself, run the following command (requires the **uuidgen** command):
+   
+       xenstore-write data/host/$(uuidgen) '{"name":"resetnetwork", "value":""}'
+
+3. After you recover networking, run the following command or rebooting continues to break networking:
 
          echo -e 'network:\n  config: disabled' >> /etc/cloud/cloud.cfg.d/10_rackspace.cfg
 

--- a/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
+++ b/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
@@ -6,7 +6,7 @@ type: article
 created_date: '2019-01-18'
 created_by: Rackspace Community
 last_modified_date: '2019-11-15'
-last_modified_by: Erik Wilson
+last_modified_by: William Loy
 product: Cloud Servers
 product_url: cloud-servers
 ---
@@ -50,26 +50,33 @@ This command stops the **cloud-init** application from deleting your `eth0` conf
 
 If you have rebooted and networking is down, complete the following steps:
 
-1. Check that **nova-agent** is running on the server as it is required to automatically load the networking configuration.
+1. Check that **nova-agent** is running on the server as it is required to automatically load the networking configuration.   This can be checked by using the following command:
 
          systemctl is-active nova-agent
          
-   If the agent is not running, make sure to start it and set "active" on-boot.
+   If the **nova-agent** is not running, make sure to start it and set "active" on-boot with the following sequence of commands:
          
          systemctl start nova-agent
          systemctl enable nova-agent 
 
-2. Trigger the **nova-agent** to reload the network configuration by either adding a Cloud Network to the server, sending an application programming interface (API) call to "reset network", or trigger the reset locally on the server.
+2. Trigger the **nova-agent** to reload the network configuration by using one of the following options:
+
+      - Add a Cloud Network to the server, and then send an application programming interface (API) call to **resetNetwork**
+      to reset the network.
+      
+       - To use this option an [API call](https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#reset-network-for-server) must be used to trigger **resetNetwork**. 
+            [Pitchfork](https://pitchfork.rax.io/servers/#reset_network-cloud_servers) is a graphical user interface (GUI) API tool that can be used to easily access the API.
+      
+      - Trigger the network reset locally on the server.
+      
+       - To trigger the reset on the locally on the server itself, run the following command:
+
+            ```xenstore-write data/host/$(uuidgen) '{"name":"resetnetwork", "value":""}'```
  
-   If adding a new Cloud Network, make sure when you remove it that you do not remove/disconnect the existing Public or Private networks, otherwise you may lose your IP address.
-
-   You cannot trigger the "reset network" [API call](https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#reset-network-for-server) through the Rackspace MyCloud portal. You must use the API. The easiest way to use the API is with the unofficial graphical user interface (GUI) API tool, [Pitchfork](https://pitchfork.rax.io/servers/#reset_network-cloud_servers).
+  Warning: When adding a new Cloud Network,  do not remove or disconnect the existing Public or Private networks, otherwise you may lose your IP address.
    
-   To trigger the reset on the server itself, run the following command (requires the **uuidgen** command):
-   
-       xenstore-write data/host/$(uuidgen) '{"name":"resetnetwork", "value":""}'
 
-3. After you recover networking, run the following command or rebooting continues to break networking:
+3. When networking is recovered, ensure that rebooting does not continue to break networking by running the following command:
 
          echo -e 'network:\n  config: disabled' >> /etc/cloud/cloud.cfg.d/10_rackspace.cfg
 

--- a/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
+++ b/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
@@ -67,9 +67,9 @@ If you have rebooted and networking is down, complete the following steps:
       
       - Trigger the network reset locally on the server.
       
-       - To trigger the reset on the locally on the server itself, run the following command:
+        To trigger the reset on the locally on the server itself, run the following command:
 
-            ```xenstore-write data/host/$(uuidgen) '{"name":"resetnetwork", "value":""}'```
+            xenstore-write data/host/$(uuidgen) '{"name":"resetnetwork", "value":""}'
  
   Warning: When adding a new Cloud Network,  do not remove or disconnect the existing Public or Private networks, otherwise you may lose your IP address.
    

--- a/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
+++ b/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
@@ -65,9 +65,7 @@ If you have rebooted and networking is down, complete the following steps:
       
       - Use an [API call](https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#reset-network-for-server) to trigger **resetNetwork**.[Pitchfork](https://pitchfork.rax.io/servers/#reset_network-cloud_servers) is a graphical user interface (GUI) API tool that can be used to easily access the API.
       
-      - Trigger the network reset locally on the server.
-      
-        To trigger the reset on the locally on the server itself, run the following command:
+      - Trigger the network reset locally on the server by running the following command:
 
             xenstore-write data/host/$(uuidgen) '{"name":"resetnetwork", "value":""}'
  

--- a/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
+++ b/content/cloud-servers/network-configuration-for-eth0-changed-to-dhcp-after-upgrading-rhel-centos.md
@@ -61,11 +61,9 @@ If you have rebooted and networking is down, complete the following steps:
 
 2. Trigger the **nova-agent** to reload the network configuration by using one of the following options:
 
-      - Add a Cloud Network to the server, and then send an application programming interface (API) call to **resetNetwork**
-      to reset the network.
+      - Add a Cloud Network to the server.
       
-       - To use this option an [API call](https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#reset-network-for-server) must be used to trigger **resetNetwork**. 
-            [Pitchfork](https://pitchfork.rax.io/servers/#reset_network-cloud_servers) is a graphical user interface (GUI) API tool that can be used to easily access the API.
+      - Use an [API call](https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#reset-network-for-server) to trigger **resetNetwork**.[Pitchfork](https://pitchfork.rax.io/servers/#reset_network-cloud_servers) is a graphical user interface (GUI) API tool that can be used to easily access the API.
       
       - Trigger the network reset locally on the server.
       


### PR DESCRIPTION
* Add step to check `nova-agent` is running / starting on boot (essential for a network reset)
* "reset the network application programming interface (API) call" makes no sense - what you are doing is "reset the network", but you are doing it _via_ the API. You are not resetting the API :) corrected that wording...
* Adds a note about not disconnecting your existing network(s)
* Adds instruction for triggering the reset locally on the server