### PR TITLE
Article rewrite to reference current OS & Gluster versions along with best practices

### DIFF
--- a/content/cloud-servers/getting-started-with-glusterfs-considerations-and-installation.md
+++ b/content/cloud-servers/getting-started-with-glusterfs-considerations-and-installation.md
@@ -4,12 +4,14 @@ audit_date:
 title: Get started with GlusterFS - considerations and installation
 type: article
 created_date: '2014-08-14'
-created_by: Marcin Stangel
-last_modified_date: '2016-01-15'
-last_modified_by: Stephanie Fillmon
+created_by: Ryan Stark
+last_modified_date: '2019-12-20'
+last_modified_by: Ryan Stark
 product: Cloud Servers
 product_url: cloud-servers
 ---
+
+This article has been updated to cover GlusterFS 7 installation on CentOS 7 & Ubuntu 18.04.
 
 Before you start to use GlusterFS, you have to make a fundamental decision: what type of volumes do you need for your environment. The following methods are used most often to achieve different results:
 
@@ -36,94 +38,76 @@ All the fundamental work in this document is the same except for the one step wh
 
 ### Prerequisites
 
-- Two or more servers with separate storage
-- A private network between servers
+- Two or more servers with separate storage. The examples in this article are based on CentOS 7 & Ubuntu 18.04 servers
+- A private network between servers. The examples in this article will use 192.168.0.0/24
 
 ### Build setup
 
 The build described in this document uses the following setup. Using Cloud Block Storage devices is no different than using VMware vDisks, SAN/DAS LUNs, iSCSI, and so on.
 
-- Four I/O optimized Rackspace Cloud server images with a 20 GB /dev/xvde partition ready to use for each brick
-- One Cloud Private Network on 192.168.3.0/24 for GlusterFS communication
-- GlusterFS 3.5.0 installed from the vendor package repository
+- Four I/O optimized Rackspace Cloud server images with a /dev/xvde partition ready to use for each brick
+- One Cloud Private Network on 192.168.0.0/24 for GlusterFS communication
+- GlusterFS 7.1 installed from the vendor package repository
 
 ### Preparing the servers
 
 Perform the following configuration and installations to prepare the servers.
 
-1. Configure **`/etc/hosts`** and **`iptables/`**
-2. Install base toolsets
+1. Configure **`/etc/hosts`**
+2. Install OS updates
 3. Install GlusterFS software
-4. Connect GlusterFS nodes
+4. Configure network access
+5. Connect GlusterFS nodes
 
-#### Configure /etc/hosts and iptables/
+#### Configure /etc/hosts for intra-node communication
 
 Instead of using DNS, prepare **`/etc/hosts`** on every server and ensure that the servers can communicate with each other. All servers have the name <strong>gluster<em>N</em></strong> as a host name, so use <strong>glus<em>N</em></strong> for the private communication layer between servers.
 
     # vi /etc/hosts
-	192.168.3.2  glus1
-	192.168.3.4  glus2
-	192.168.3.1  glus3
-	192.168.3.3  glus4
+	192.168.0.1  glus-01
+	192.168.0.2  glus-02
+	192.168.0.3  glus-03
+	192.168.0.4  glus-04
 
-	# ping -c2 glus1; ping -c2 glus2;  ping -c2 glus3;  ping -c2 glus4
-
-**Red Hat**
-
-    # vi /etc/sysconfig/iptables
-    -A INPUT -s 192.168.3.0/24 -j ACCEPT
-
-    # service iptables restart
-
-**Granular setup for iptables**
-
-The preceding generic iptables rule opens all ports to the subnet. If a more granular setup is required, use the following values:
-
-- **111** - portmap/rpcbind
-- **24007** - GlusterFS Daemon
-- **24008** - GlusterFS Management
-- **38465** to **38467** - Required for GlusterFS NFS service
-- **24009** to **+X** - GlusterFS versions earlier than 3.4
-- **49152** to **+X** - GlusterFS versions 3.4 and later
-
-Each brick for every volume on the host requires its own port. For every new brick, one new port will be used starting at **24009** for GlusterFS versions earlier than 3.4 and **49152** for version 3.4 and later.
-
-For example, if you have one volume with two bricks, you must open 24009-24010 or 49152-49153.
+	# ping -c2 glus-01; ping -c2 glus-02;  ping -c2 glus-03;  ping -c2 glus-04
 
 #### Install packages
 
 Run the commands in this section to perform the following steps:
 
-1.	Install the basic packages for partitioning, LVM2 and XFS
+1.	Install OS updates
 2.	Install the GlusterFS repository and GlusterFS packages
-3.	Disable automatic updates of Gluster packages
 
-Some of the required packages might already be installed on the cluster nodes.
+**CentOS**
 
-**YUM/RPM**
-
-    yum -y install parted lvm2 xfsprogs
-    wget -P /etc/yum.repos.d
-    http://download.gluster.org/pub/gluster/glusterfs/LATEST/CentOS/glusterfs-epel.repo
-    yum -y install glusterfs glusterfs-fuse glusterfs-server
+    yum update -y
+    yum install -y centos-release-gluster7
+    yum install -y glusterfs-server
 
 **Ubuntu**
 
-The default Ubuntu repository has glusterfs 3.4.2 installed. Use the following code to install 3.5.1:
+The default Ubuntu repository has glusterfs 3.13.2 installed. Use the following code to install 7.1:
 
-    apt-get install lvm2 xfsprogs python-software-properties
-    add-apt-repository ppa:semiosis/ubuntu-glusterfs-3.5
-    apt-get update
-    apt-get install glusterfs-server
+    apt update
+    apt upgrade -y
+    add-apt-repository -y ppa:gluster/glusterfs-7
+    apt install -y glusterfs-server
 
-Use the following commands to ensure that the gluster* packages are filtered out of automatic updates. Upgrades while it's running can crash the bricks (on at least the upgrade from 3.5.0 to 3.5.1).
+#### Configure network access
 
-    grep ^exclude /etc/yum.conf
-    exclude=kernel* gluster*
+**CentOS**
+
+These commands will allow Gluster traffic between your nodes and allow client mounts.
+
+    firewall-cmd --add-service=glusterfs
+    firewall-cmd --add-service=glusterfs --permanent
 
 **Ubuntu**
 
-    apt-mark hold glusterfs*
+These commands will allow all traffic over your private network segmenyt to facilitate Gluster communication.
+
+    ufw enable
+    ufw allow from 192.168.0.0/24
 
 #### Prepare the bricks
 
@@ -144,28 +128,27 @@ The bricks must be unique per node, and there should be a directory within the m
     parted -s -- /dev/xvde mktable gpt
     parted -s -- /dev/xvde mkpart primary 2048s 100%
     parted -s -- /dev/xvde set 1 lvm on
-    partx -a /dev/xvde
     pvcreate /dev/xvde1
-    vgcreate vgglus1 /dev/xvde1
-    lvcreate -l 100%VG -n gbrick1 vgglus1
-    mkfs.xfs -i size=512 /dev/vgglus1/gbrick1
-    echo '/dev/vgglus1/gbrick1 /var/lib/gvol0 xfs inode64,nobarrier 0 0' >> /etc/fstab
+    vgcreate vgglus-01 /dev/xvde1
+    lvcreate -l 100%VG -n gbrick1 vgglus-01
+    mkfs.xfs /dev/vgglus-01/gbrick1
+    echo '/dev/vgglus-01/gbrick1 /var/lib/gvol0 xfs defaults 0 0' >> /etc/fstab
     mkdir /var/lib/gvol0
     mount /var/lib/gvol0
 
--  glus1
+-  glus-01
 
         mkdir /var/lib/gvol0/brick1
 
--  glus2
+-  glus-02
 
         mkdir /var/lib/gvol0/brick2
 
--  glus3
+-  glus-03
 
         mkdir /var/lib/gvol0/brick3
 
--  glus4
+-  glus-04
 
         mkdir /var/lib/gvol0/brick4
 
@@ -177,49 +160,39 @@ Use the steps below to run the GlusterFS setup.
 
 The daemon can also be restarted at run time:
 
-**Red Hat**
-
-    service glusterd start
-    chkconfig glusterd on
+    systemctl enable glusterd
+    systemctl start glusterd
 
 ### Build a peer group
 
 A peer group is known as a *trusted storage pool* in GlusterFS.
 
--  glus1
+-  glus-01
 
-       gluster peer probe glus2
-       gluster peer probe glus3
-       gluster peer probe glus4
+       gluster peer probe glus-02
+       gluster peer probe glus-03
+       gluster peer probe glus-04
        gluster peer status
 
--  glus2
+-  glus-02
 
-       gluster peer probe glus1
-       gluster peer probe glus3
-       gluster peer probe glus4
-       gluster peer status1
-
--  glus3
-
-       gluster peer probe glus1
-       gluster peer probe glus2
-       gluster peer probe glus4
        gluster peer status
 
--  glus4
-       gluster peer probe glus1
-       gluster peer probe glus2
-       gluster peer probe glus3
+-  glus-03
+
+       gluster peer status
+
+-  glus-04
+
        gluster peer status
 
 Now you can verify the status of your node and the gluster server pool:
 
     [root@gluster1 ~]# gluster pool list
     UUID	                				Hostname	State
-    734aea4c-fc4f-4971-ba3d-37bd5d9c35b8	glus4   	Connected
-    d5c9e064-c06f-44d9-bf60-bae5fc881e16	glus3   	Connected
-    57027f23-bdf2-4a95-8eb6-ff9f936dc31e	glus2   	Connected
+    734aea4c-fc4f-4971-ba3d-37bd5d9c35b8	glus-04   	Connected
+    d5c9e064-c06f-44d9-bf60-bae5fc881e16	glus-03   	Connected
+    57027f23-bdf2-4a95-8eb6-ff9f936dc31e	glus-02   	Connected
     e64c5148-8942-4065-9654-169e20ed6f20	localhost	Connected
 
 ### Create the volume
@@ -233,35 +206,30 @@ This example creates replication to all four nodes; each node contains a copy of
 **One node only**:
 
      gluster volume create gvol0 replica 4 transport tcp \
-     glus1:/var/lib/gvol0/brick1 \
-     glus2:/var/lib/gvol0/brick2 \
-     glus3:/var/lib/gvol0/brick3 \
-     glus4:/var/lib/gvol0/brick4
-     gluster volume set gvol0 auth.allow 192.168.3.*
-     gluster volume set gvol0 nfs.disable off
-     gluster volume set gvol0 nfs.addr-namelookup off
-     gluster volume set gvol0 nfs.export-volumes on
-     gluster volume set gvol0 nfs.rpc-auth-allow 192.168.3.*
+     glus-01:/var/lib/gvol0/brick1 \
+     glus-02:/var/lib/gvol0/brick2 \
+     glus-03:/var/lib/gvol0/brick3 \
+     glus-04:/var/lib/gvol0/brick4
      gluster volume start gvol0
 
     [root@gluster1 ~]# gluster volume info gvol0
+
     Volume Name: gvol0
     Type: Replicate
-    Volume ID: 65ece3b3-a4dc-43f8-9b0f-9f39c7202640
+    Volume ID: 8d12cb5a-77ad-43a3-bdd1-ab48405ff1da
     Status: Started
+    Snapshot Count: 0
     Number of Bricks: 1 x 4 = 4
     Transport-type: tcp
     Bricks:
-    Brick1: glus1:/var/lib/gvol0/brick1
-    Brick2: glus2:/var/lib/gvol0/brick2
-    Brick3: glus3:/var/lib/gvol0/brick3
-    Brick4: glus4:/var/lib/gvol0/brick4
+    Brick1: glus-01:/var/lib/gvol0/brick1
+    Brick2: glus-02:/var/lib/gvol0/brick2
+    Brick3: glus-03:/var/lib/gvol0/brick3
+    Brick4: glus-04:/var/lib/gvol0/brick4
     Options Reconfigured:
-    nfs.rpc-auth-allow: 192.168.3.*
-    nfs.export-volumes: on
-    nfs.addr-namelookup: off
-    nfs.disable: off
-    auth.allow: 192.168.3.*
+    transport.address-family: inet
+    storage.fips-mode-rchecksum: on
+    performance.client-io-threads: off
 
 #### Distributed-Replicated volume
 
@@ -270,35 +238,30 @@ This example creates distributed replication to 2x2 nodes; each pair of nodes co
 **One node only**:
 
     gluster volume create gvol0 replica 2 transport tcp \
-    glus1:/var/lib/gvol0/brick1 \
-    glus2:/var/lib/gvol0/brick2 \
-    glus3:/var/lib/gvol0/brick3 \
-    glus4:/var/lib/gvol0/brick4
-    gluster volume set gvol0 auth.allow 192.168.3.*
-    gluster volume set gvol0 nfs.disable off
-    gluster volume set gvol0 nfs.addr-namelookup off
-    gluster volume set gvol0 nfs.export-volumes on
-    gluster volume set gvol0 nfs.rpc-auth-allow 192.168.3.*
+    glus-01:/var/lib/gvol0/brick1 \
+    glus-02:/var/lib/gvol0/brick2 \
+    glus-03:/var/lib/gvol0/brick3 \
+    glus-04:/var/lib/gvol0/brick4
     gluster volume start gvol0
 
     [root@gluster1 ~]# gluster volume info gvol0
+
     Volume Name: gvol0
     Type: Distributed-Replicate
-    Volume ID: d883f891-e38b-4565-8487-7e50ca33dbd4
+    Volume ID: b2ddd34b-ffb4-4fd8-ae60-b90adbd4c2ab
     Status: Started
+    Snapshot Count: 0
     Number of Bricks: 2 x 2 = 4
     Transport-type: tcp
     Bricks:
-    Brick1: glus1:/var/lib/gvol0/brick1
-    Brick2: glus2:/var/lib/gvol0/brick2
-    Brick3: glus3:/var/lib/gvol0/brick3
-    Brick4: glus4:/var/lib/gvol0/brick4
+    Brick1: glus-01:/var/lib/gvol0/brick1
+    Brick2: glus-02:/var/lib/gvol0/brick2
+    Brick3: glus-03:/var/lib/gvol0/brick3
+    Brick4: glus-04:/var/lib/gvol0/brick4
     Options Reconfigured:
-    nfs.rpc-auth-allow: 192.168.3.*
-    nfs.export-volumes: on
-    nfs.addr-namelookup: off
-    nfs.disable: off
-    auth.allow: 192.168.3.*
+    transport.address-family: inet
+    storage.fips-mode-rchecksum: on
+    performance.client-io-threads: off
 
 ### Delete the volume
 
@@ -313,68 +276,68 @@ If bricks are used in a volume and they need to be removed, you can use the foll
 
 GlusterFS set an attribute on the brick subdirectories. Clear this attribute, and then the bricks can be reused.
 
--  glus1:
+-  glus-01:
 
       setfattr -x trusted.glusterfs.volume-id /var/lib/gvol0/brick1/
       setfattr -x trusted.gfid /var/lib/gvol0/brick1
       rm -rf /var/lib/gvol0/brick1/.glusterfs
 
--  glus2:
+-  glus-02:
 
       setfattr -x trusted.glusterfs.volume-id /var/lib/gvol0/brick2/
       setfattr -x trusted.gfid /var/lib/gvol0/brick2
       rm -rf /var/lib/gvol0/brick2/.glusterfs
 
--  glus3:
+-  glus-03:
 
       setfattr -x trusted.glusterfs.volume-id /var/lib/gvol0/brick3/
-      setfattr -x trusted.gfid /var/lib/gvol0/brick2
+      setfattr -x trusted.gfid /var/lib/gvol0/brick3
       rm -rf /var/lib/gvol0/brick3/.glusterfs
 
--  glus4:
+-  glus-04:
 
       setfattr -x trusted.glusterfs.volume-id /var/lib/gvol0/brick4/
-      setfattr -x trusted.gfid /var/lib/gvol0/brick2
+      setfattr -x trusted.gfid /var/lib/gvol0/brick4
       rm -rf /var/lib/gvol0/brick4/.glusterfs
 
 Alternatively, you can delete the subdirectories and then re-create them.
 
--  glus1
+-  glus-01
 
       rm -rf /var/lib/gvol0/brick1
       mkdir /var/lib/gvol0/brick1
 
--  glus2:
+-  glus-02:
 
       rm -rf /var/lib/gvol0/brick2
       mkdir /var/lib/gvol0/brick2
 
--  glus3:
+-  glus-03:
 
       rm -rf /var/lib/gvol0/brick3
       mkdir /var/lib/gvol0/brick3
 
--  glus4:
+-  glus-04:
 
       rm -rf /var/lib/gvol0/brick4
       mkdir /var/lib/gvol0/brick4
 
 ### Add bricks
 
-You can add more bricks to a running volume, as follows:
+You can add more bricks to a running volume. Adding an additional brick to our replcated volume example above as follows:
 
-    gluster add-brick gvol0 gluster5:/var/lib/gvol0/brick5
+    gluster volume add-brick gvol0 replica 5 gluster5:/var/lib/gvol0/brick5
 
 The `add-brick` command can also be used to change the layout of your volume; for example, to change a two-node Distributed volume into a four-node Distributed-Replicated volume. After such an operation, you *must rebalance* your volume. New files will be automatically created on the new nodes, but the old ones will not get moved.
 
     gluster volume add-brick gvol0 replica 2 \
     gluster5:/var/lib/gvol0/brick5 ;
     gluster6:/var/lib/gvol0/brick6
-    gluster rebalance gvol0 start
-    gluster rebalance gvol0 status
+    gluster volume rebalance gvol0 start
+    gluster volume rebalance gvol0 status
 
     ## If needed (something didn't work right)
-    gluster rebalance gvol0 stop
+    gluster volume rebalance gvol0 stop
 
 ### Volume options
 
@@ -386,24 +349,20 @@ Following is example output:
 
     Volume Name: gvol0
     Type: Replicate
-    Volume ID: bcbfc645-ebf9-4f83-b9f0-2a36d0b1f6e3
+    Volume ID: 8d12cb5a-77ad-43a3-bdd1-ab48405ff1da
     Status: Started
+    Snapshot Count: 0
     Number of Bricks: 1 x 4 = 4
     Transport-type: tcp
     Bricks:
-    Brick1: glus1:/var/lib/gvol0/brick1
-    Brick2: glus2:/var/lib/gvol0/brick2
-    Brick3: glus3:/var/lib/gvol0/brick3
-    Brick4: glus4:/var/lib/gvol0/brick4
+    Brick1: glus-01:/var/lib/gvol0/brick1
+    Brick2: glus-02:/var/lib/gvol0/brick2
+    Brick3: glus-03:/var/lib/gvol0/brick3
+    Brick4: glus-04:/var/lib/gvol0/brick4
     Options Reconfigured:
-    performance.cache-size: 1073741824
-    performance.io-thread-count: 64
-    cluster.choose-local: on
-    nfs.rpc-auth-allow: 192.168.3.*
-    nfs.export-volumes: on
-    nfs.addr-namelookup: off
-    nfs.disable: off
-    auth.allow: 192.168.3.*
+    transport.address-family: inet
+    storage.fips-mode-rchecksum: on
+    performance.client-io-threads: off
 
 To set an option for a volume, use the **set** keyword, as follows:
 
@@ -418,68 +377,42 @@ To clear an option to a volume back to the default, use the **reset** keyword as
 
 ### Client mounts
 
-From a client perspective, the GlusterFS volume can be mounted in the following ways:
-
-- FUSE client
-- NFS client
+The preferred method for a client to mount a GlusterFS volume is by using the native FUSE client. NFS mounts are possible when GlusterFS is deployed in tandem with NFS-Ganesha, which we'll look at in a furture article.
 
 #### FUSE client
 
-The FUSE client allows the mount to happen with a GlusterFS "round robin" style connection. In **/etc/fstab**, the name of one node is used; however, internal mechanisms allow that node to fail, and the clients will roll over to other connected nodes in the trusted storage pool. The performance is slightly slower than the NFS method based on tests, but not drastically so. The gain is automatic HA client failover, which is typically worth the effect on performance.
+The FUSE client allows the mount to happen with a GlusterFS "round robin" style connection. In **/etc/fstab**, the name of one node is used; however, internal mechanisms allow that node to fail, and the clients will roll over to other connected nodes in the trusted storage pool.
 
-**RPM**:
+**CentOS**:
 
-    wget -P /etc/yum.repos.d
-    http://download.gluster.org/pub/gluster/glusterfs/LATEST/CentOS/glusterfs-epel.repo
-    yum -y install glusterfs glusterfs-fuse
+    yum install -y centos-release-gluster7
+    yum install -y glusterfs-fuse
 
 **Ubuntu**:
 
-glusterfs-client 3.4.2 works with glusterfs-server 3.5.1, but for the most recent version, use the following code:
-
-    add-apt-repository ppa:semiosis/ubuntu-glusterfs-3.5
-    apt-get update
-    apt-get install glusterfs-client
+    add-apt-repository -y ppa:gluster/glusterfs-7
+    apt install glusterfs-client
 
 **Common**:
 
     vi /etc/hosts
-    192.168.3.2  glus1
-    192.168.3.4  glus2
-    192.168.3.1  glus3
-    192.168.3.3  glus4
+    192.168.0.2  glus-01
+    192.168.0.4  glus-02
+    192.168.0.1  glus-03
+    192.168.0.3  glus-04
 
     modprobe fuse
-    echo 'glus1:/gvol0 /mnt/gluster/gvol0 glusterfs defaults_netdev 0 0' >> /etc/fstab
-    mkdir -p /mnt/gluster/gvol0
-    mount /mnt/gluster/gvol0
-
-#### NFS client
-
-The standard Linux NFSv3 client tools are used to mount one of the GlusterFS nodes. The performance is typically a little better than when using the FUSE client. However, the disadvantage of using this client is that the connection is 1-to-1. If the GlusterFS node fails, the client will not round-robin out to another node. A different solution must be added, such as HAProxy/keepalived or a load balancer,  to provide a floating IP proxy.
-
-**RPM based**:
-
-    yum -y install rpcbind nfs-utils
-    service rpcbind restart; chkconfig rpcbind on
-    service nfslock restart; chkconfig on
-
-**Ubuntu**:
-
-    apt-get install nfs-common
-
-**Common:**
-
-    echo 'glus1:/repvol1 /mnt/gluster/gvol0 nfs rsize=4096,wsize=4096,hard,intr 0 0' >> /etc/fstab
+    echo 'glus-01:/gvol0 /mnt/gluster/gvol0 glusterfs _netdev 0 0' >> /etc/fstab
     mkdir -p /mnt/gluster/gvol0
     mount /mnt/gluster/gvol0
 
 ### References
 
-- http://www.sohailriaz.com/glusterfs-howto-on-centos-6-x/
-- http://kaivanov.blogspot.com/2012/07/deploying-glusterfs.html
-- http://joejulian.name/blog/glusterfs-path-or-a-prefix-of-it-is-already-part-of-a-volume/
-- http://www.jamescoyle.net/how-to/457-glusterfs-firewall-rules
+- https://www.gluster.org/announcing-gluster-7-0/
+- https://docs.gluster.org/en/latest/
+- https://wiki.centos.org/HowTos/GlusterFSonCentOS
+- https://kifarunix.com/install-and-setup-glusterfs-on-ubuntu-18-04/
+- https://launchpad.net/~gluster
 
 ###Next Article
 


### PR DESCRIPTION
Gluster 7.1 installation guide on CentOS 7 & Ubuntu 18.04.
