### PR TITLE
Fix formatting and add note for filesystem command

### DIFF
--- a/content/cloud-servers/linux-device-does-not-show-the-correct-disk-space-after-a-resize.md
+++ b/content/cloud-servers/linux-device-does-not-show-the-correct-disk-space-after-a-resize.md
@@ -37,9 +37,9 @@ This option leaves the root partition unchanged and leaves any additional space 
 With the manual disk configuration, the root partition shows as unchanged after the resize completes.
 To correct this error, use the following command to perform a file system extension:
 
-    resize2fs /dev/xvd(xx)
+    resize2fs /dev/xvd<xx>
 
-**NOTE**: You'll need to replace the `(xx)` portion of the command with the appropriate filesystem name. (Ex.: `/dev/xvda1`)
+**NOTE**: You need to replace the `<xx>` portion of the command with the appropriate filesystem name, such as `/dev/xvda1`.
 
 After the command completes, rerun the ``df -h`` command to confirm success. You should see output similar to the following:
 

--- a/content/cloud-servers/linux-device-does-not-show-the-correct-disk-space-after-a-resize.md
+++ b/content/cloud-servers/linux-device-does-not-show-the-correct-disk-space-after-a-resize.md
@@ -1,12 +1,12 @@
 ---
 permalink: linux-device-does-not-show-the-correct-disk-space-after-a-resize/
-audit_date: '2020-03-23'
+audit_date: '2020-03-24'
 title: Linux device does not show the correct disk space after a resize
 type: article
 created_date: '2020-03-10'
 created_by: John Garcia
-last_modified_date: '2020-03-23'
-last_modified_by: Cat Lookabaugh
+last_modified_date: '2020-03-24'
+last_modified_by: Chris Silva
 product: Cloud Servers
 product_url: cloud-servers
 ---
@@ -26,12 +26,12 @@ This option leaves the root partition unchanged and leaves any additional space 
 **Note:** Use the ``df -h``  command to view filesystem information, such as **Name**, **Size**, **Used Space**,
 **Available Space**, **Use Percentage**, and **Mount**. 
 
-#### Sample df -h command output
+#### Sample ``df -h`` command output
 
-```[root@expanse ~]# df -h
-Filesystem      Size  Used Avail Use% Mounted on
-/dev/xvda1       40G  1.7G   36G   5% /
-```
+    [root@expanse ~]# df -h
+    Filesystem      Size  Used Avail Use% Mounted on
+    /dev/xvda1       40G  1.7G   36G   5% /
+
 ### The issue and the solution
 
 With the manual disk configuration, the root partition shows as unchanged after the resize completes.
@@ -39,9 +39,11 @@ To correct this error, use the following command to perform a file system extens
 
     resize2fs /dev/xvd(xx)
 
+**NOTE**: You'll need to replace the `(xx)` portion of the command with the appropriate filesystem name. (Ex.: `/dev/xvda1`)
+
 After the command completes, rerun the ``df -h`` command to confirm success. You should see output similar to the following:
 
-```[root@expanse ~]# df -h
-Filesystem      Size  Used Avail Use% Mounted on
-/dev/xvda1       79G  1.7G   74G   3% /
-```
+    [root@expanse ~]# df -h
+    Filesystem      Size  Used Avail Use% Mounted on
+    /dev/xvda1       79G  1.7G   74G   3% /
+    


### PR DESCRIPTION
Fixed formatting for terminal output on article. 

Also, I added a note box under the command example for clarification.  I think that line might have been in a previous iteration of the article before it was submitted. Figured it couldn't hurt to add the extra info, so I added it to the page.

