### PR TITLE
Retire Cloud Files Ruby sample article

### DIFF
--- a/content/retired-articles/sample-ruby-application-for-cloud-files.md
+++ b/content/retired-articles/sample-ruby-application-for-cloud-files.md
@@ -7,8 +7,6 @@ created_date: '2011-03-16'
 created_by: Rackspace Support
 last_modified_date: '2016-04-18'
 last_modified_by: Stephanie Fillmon
-product: Cloud Files
-product_url: cloud-files
 ---
 
 *From Connection to Objects*


### PR DESCRIPTION
This work addresses this JIRA https://jira.rax.io/browse/INFODEV-3921.

Retire file after research provided by Maeve Goetz that using the code does work but produces errors. Here is email from Maeve on 5/27:

Hi Catherine,

Sorry for the delay replying, took a little while to be able to carve out some time to get the code on the support page tested.  It does still work, though the gem it requires throws warnings about part of it being obsolete, So, I don't think there will be an issue getting rid of the page.  

We also have information on https://developer.rackspace.com/docs/cloud-files/quickstart/ for using Ruby with Cloud Files that seems to be more up-to-date than the support page you referenced.

Thanks again for reaching out and again, I'm sorry we took so long to get back with you.

- Maeve