### PR TITLE
Update IUS release package URL

### DIFF
--- a/content/cloud-servers/install-epel-and-additional-repositories-on-centos-and-red-hat.md
+++ b/content/cloud-servers/install-epel-and-additional-repositories-on-centos-and-red-hat.md
@@ -64,7 +64,7 @@ one enabled repository.
 
 To install the IUS release package, run the following command:
 
-    sudo yum install https://$(rpm -E '%{?centos:centos}%{!?centos:rhel}%{rhel}').iuscommunity.org/ius-release.rpm
+    sudo yum install https://repo.ius.io/ius-release-el$(rpm -E '%{rhel}').rpm
 
 ### Upgrade installed packages to IUS versions
 


### PR DESCRIPTION
The old URLs (e.g. https://centos7.iuscommunity.org/ius-release.rpm,
https://rhel7.iuscommunity.org/ius-release.rpm) are broken.

See commit 5b1bf8e133fef3c12b61024df97d76df43888c81 of
https://github.com/iuscommunity/automation-examples

