### PR TITLE
add warning about mailbox names

### DIFF
--- a/content/rackspace-email/email-migration-services.md
+++ b/content/rackspace-email/email-migration-services.md
@@ -1,6 +1,6 @@
 ---
 permalink: email-migration-services/
-audit_date: '2017-11-03'
+audit_date: '2020-07-08'
 title: Email migration services
 type: article
 created_date: '2013-07-15'

--- a/content/rackspace-email/email-migration-services.md
+++ b/content/rackspace-email/email-migration-services.md
@@ -1,12 +1,12 @@
 ---
 permalink: email-migration-services/
-audit_date: '2016-11-03'
+audit_date: '2017-11-03'
 title: Email migration services
 type: article
 created_date: '2013-07-15'
 created_by: Rackspace Support
-last_modified_date: '2017-07-03'
-last_modified_by: William Loy
+last_modified_date: '2020-07-08'
+last_modified_by: Stephanie Fillmon
 product: Rackspace Email
 product_url: rackspace-email
 ---
@@ -21,6 +21,10 @@ you have any questions or concerns.
 - **Difficulty:** Easy
 - **Time needed:** Dependent on migration type
 - **Tools required:** Cloud Office Control Panel access
+
+**Warning**: Special characters in mailbox folder names cause the migration
+to fail. Before migrating your data, be sure to remove any special characters
+from your mailbox folders: `! @ # $ % ^ & * ( ) + = < , > ? / ; : " ' { } [ ] \ | .`
 
 For more information about prerequisite terminology, see [Cloud Office support terminology](/how-to/cloud-office-support-terminology).
 

--- a/content/rackspace-email/email-migration-services.md
+++ b/content/rackspace-email/email-migration-services.md
@@ -11,15 +11,15 @@ product: Rackspace Email
 product_url: rackspace-email
 ---
 
-We offer a number of email migration services to our customers at no
-charge. Our team of email migration experts are here to help you in case
+We offer several email migration services to our customers at no
+charge. Our team of email migration experts is here to help you if
 you have any questions or concerns.
 
 ### Prerequisites
 
 - **Applies to:** Administrator
 - **Difficulty:** Easy
-- **Time needed:** Dependent on migration type
+- **Time needed:** Depends on the migration type
 - **Tools required:** Cloud Office Control Panel access
 
 **Warning**: Special characters in mailbox folder names cause the migration
@@ -30,34 +30,34 @@ For more information about prerequisite terminology, see [Cloud Office support t
 
 ### External migration services
 
-If you are a new customer and require email data to be migrated from another provider, we can help. We provide two migration
-support options to make your transition as easy as possible: self-service migration, and assisted migration.
+If you are a new customer and need to migrate email data from another provider, we can help. We provide two migration
+support options to make your transition as easy as possible: self-service migration and assisted migration.
 
 #### Self-service migration
 
-Run your migration at any time of the day or night with MigrationWiz, which you can access in the Cloud Office Control Panel. For instructions on how to use MigrationWiz, see [Migrate your email by using the self-service migration tool](/how-to/migrate-your-email-by-using-the-self-service-migration-tool/).
+Run your migration at any time, day or night, with **MigrationWiz**, which you can access in the Cloud Office Control Panel. For instructions on how to use **MigrationWiz**, see [Migrate your email by using the self-service migration tool](/how-to/migrate-your-email-by-using-the-self-service-migration-tool/).
 
-The benefits of using the self-migration tool:
+The self-migration tool includes the following benefits:
 
--   Migrate from any provider to Hosted Exchange, Rackspace Email, or Rackspace Office 365
+-   Migrates from any provider to Hosted Exchange&reg;, Rackspace Email, or Rackspace Office 365
 -   Includes a no-cost migration
 -   Migrates contacts, calendars, tasks, and notes data when moving from
     Exchange to Exchange
--   Provides real-time email notifications through the migration process
--   Direct access to view your migration status
+-   Provides real-time email notifications throughout the migration process
+-   Offers direct access to view your migration status
 -   Can be accessed from any Internet browser
--   24x7 support provided by a team of email experts
+-   Includes 24x7 support provided by a team of email experts
 
-**Note:** Current customers seeking to upgrade to Office 365 should review [Rackspace Email and Microsoft Exchange upgrade to Office 365 FAQ](/how-to/upgrade-rackspace-email-and-microsoft-exchange-to-office-365-faq) for questions and instructions on the process.
+**Note:** Current customers seeking to upgrade to Microsoft&reg; Office 365&reg; should review [Rackspace Email and Microsoft Exchange upgrade to Office 365 FAQ](/how-to/upgrade-rackspace-email-and-microsoft-exchange-to-office-365-faq) for questions and instructions on the process.
 
 #### Assisted migration
 
 Assisted migrations are ideal for companies that need help consulting,
 planning, and scheduling a migration project. Our assisted migration
-service will provide you with peace of mind knowing that your migration
-is being coordinated by the best team of email migration experts.
+service provides you with peace of mind knowing that the best team of
+email migration experts is coordinating your migration.
 
-The benefits of choosing an assisted migration are as follows:
+The benefits of choosing an assisted migration include the following elements:
 
 -   A migration specialist dedicated to your project
 -   A custom migration plan based on consultation with your specialist
@@ -67,12 +67,11 @@ The benefits of choosing an assisted migration are as follows:
     end-users
 
 Assisted Migrations are a partnership between your company and our
-team of experts. Throughout the process we will require some action and
+team of experts. Throughout the process, we will require some action and
 information from you.
 
 Migrations vary based on the type of mailboxes we are migrating to and
-from. See the following chart for a list of what will migrate using
-our services:
+from. See the following chart for a list of which services migrate with assisted migration:
 
 | Current Service    | Rackspace service | Mail inbox | Mail subfolders | Contacts | Calendar | Tasks | Notes |
 |--------------------|-------------------|------------|-----------------|----------|----------|-------|-------|
@@ -89,19 +88,20 @@ our services:
 
 ### Internal migration services
 
-The Rackspace internal migration services can help you rename email accounts, change domain names, switch to a new email platform, and more. Submit a request via a ticket and we'll take care of the rest.
+The Rackspace internal migration services can help you rename email accounts, change domain names, switch
+to a new email platform, and more. Submit a request by using a ticket, and we take care of the rest.
 
 | Service | Cost | Notes |How to request migration|
 | --- | --- | --- | --- |
 | **Upgrade from Exchange 2007, 2010, or 2013 to Exchange 2016** | No charge | This type of migration requires all users on the domain to migrate. | See [Upgrading to Exchange 2016](/how-to/upgrading-to-exchange-2016/) for self-scheduled Exchange upgrade instructions.|
 | **Platform changes** | No charge | - Convert from Rackspace Email to Microsoft Exchange and keep the same address.<br/><br/> - Convert from Exchange to Rackspace Email and keep the same address.| Submit a support ticket to request either platform change.|
 | **Domain rename** | No charge | $50 if Rackspace archiving is enabled for the domain. | Submit a support ticket requesting this service.|
-| **Hosted Exchange Mailbox rename** | No charge | [Rackspace Email  mailboxes can be renamed inside your mail control panel.](/how-to/rename-a-rackspace-email-mailbox/) | Submit a support ticket requesting this service. |
+| **Hosted Exchange Mailbox rename** | No charge | [You can rename Rackspace Email  mailboxes inside your mail Control Panel.](/how-to/rename-a-rackspace-email-mailbox/) | Submit a support ticket requesting this service. |
 | **Mailbox data migrations** | No charge | Migrate data from **OneUser@domain**.com to **DifferentUser@domain**.com. | Submit a support ticket requesting this service. |
 
-**Note**: Charges for internal migration services are applied to the
-next month's statement.
+**Note**: Charges for internal migration services are applied to the next month's statement.
 
 #### Self-service Exchange Upgrade Tool
 
-Customers can schedule and run their own Hosted Exchange upgrades at rackspacemigrations.com. For more information, see [Upgrading to Exchange 2016](/how-to/upgrading-to-exchange-2016/).
+Customers can schedule and run their own Hosted Exchange upgrades at rackspacemigrations.com. For more
+information, see [Upgrading to Exchange 2016](/how-to/upgrading-to-exchange-2016/).


### PR DESCRIPTION
JIRA 6087

Special characters in mailbox folder names cause email migration to fail, so this PR adds a warning in the prerequisites section to remove any special characters from folder names.