### PR TITLE
Fix steps displayed on production page

### DIFF
--- a/content/cloud-load-balancers/configure-SSL-certificates-on-cloud-load-balancers.md
+++ b/content/cloud-load-balancers/configure-SSL-certificates-on-cloud-load-balancers.md
@@ -32,6 +32,7 @@ The following table shows the possible response codes for the operation:
 500|Load Balancer Fault|The load balancer has experienced a fault.
 503|Service Unavailable|The service is not available.
 
+
 ### Prerequisites
 
 - You must create an HTTP (port 80) load balancer.

--- a/content/cloud-load-balancers/configure-SSL-certificates-on-cloud-load-balancers.md
+++ b/content/cloud-load-balancers/configure-SSL-certificates-on-cloud-load-balancers.md
@@ -49,7 +49,11 @@ The following table shows the possible response codes for the operation:
 
 4. Paste the SSL certificate data into the appropriate boxes.
 
-**NOTE**: You can choose to allow secure and insecure traffic. However, when terminating the SSL on the load balancer, you should only allow secure traffic, as a best practice. You can also select your Transport Layer Security (**TLS**) and **Cipher Profile** in this section. For more information about your **Cipher Profile**, see [Update Cipher Profile on Cloud Load Balancer](/how-to/update-the-cipher-profile-on-a-cloud-load-balancer). For more information on TLS version, see [Disable TLS 1.0 Cloud Load Balancers](/how-to/disable-tls1-for-cloud-load-balancers/).
+    **NOTE**: You can choose to allow secure and insecure traffic. However, when terminating the SSL on the load
+    balancer, you should only allow   secure traffic, as a best practice. You can also select your Transport Layer
+    Security (**TLS**) and **Cipher Profile** in this section. For more information about your **Cipher Profile**,
+    see [Update Cipher Profile on Cloud Load Balancer](/how-to/update-the-cipher-profile-on-a-cloud-load-balancer).
+    For more information on TLS version, see [Disable TLS 1.0 Cloud Load Balancers](/how-to/disable-tls1-for-cloud-load-balancers/).
 
 5. Click **Save Configuration** to apply the certificate. 
 


### PR DESCRIPTION
Not sure how to fix this, but on the live page, under the "Apply the SSL certificate to a Cloud Load Balancer", the step to Save Configuration is numbered as Step 1, but the code indicates that it's properly labeled as Step 5.

Also, I added an empty line under the table to help space the section out a bit.. 