### PR TITLE
DO NOT MERGE retire article about cloud sites

### DIFF
--- a/content/retired-articles/linux-htaccess-tips-and-tricks.md
+++ b/content/retired-articles/linux-htaccess-tips-and-tricks.md
@@ -7,8 +7,6 @@ created_date: '2019-02-14'
 created_by: Rackspace Community
 last_modified_date: '2019-02-19'
 last_modified_by: Kate Dougherty
-product: Cloud Servers
-product_url: cloud-servers
 ---
 
 This article is intended for use with the following technologies:


### PR DESCRIPTION
This article is full of references to Cloud Sites, which hasn't been around for a long time. All of the instructions are for Cloud Sites users, so I'm retiring this instead of trying to rewrite it.