### PR TITLE
Update set-up-mysql-primary-replica-replication.md

### DIFF
--- a/content/cloud-servers/set-up-mysql-primary-replica-replication.md
+++ b/content/cloud-servers/set-up-mysql-primary-replica-replication.md
@@ -161,9 +161,9 @@ replication.
     replica (`db02`) server.
 
 4.  Use the following command to ensure that nothing can write to the
-    primary database during a database dump: Also note the filename and
+    primary database during a database dump. Also note the filename and
     position of the binary log because you need these values to
-    complete the replication configuration on db02.
+    complete the replication configuration on db02:
 
 
         # mysql -u root -p
@@ -177,18 +177,19 @@ replication.
         +------------------+--------------------------+------------------+
         1 row in set (0.00 sec)
 
-      **Note:** Record the filename and position of the binary log because you need these values to
+      **Note 1:** Record the filename and position of the binary log because you need these values to
       complete the replication configuration on `db02`.
-
+      
+      **Note 2:** Keep this session open, closing it releases the lock!
+      
 5.  Perform a database dump by using `mysqldump` as follows:
 
         # mysqldump -u root -p --databases [database-1] [database-2] ...  > /root/db_dump.sql
 
-6.  After the database dump has completed, lift the read lock from the
-    primary (`db01`):
+6.  After the database dump has completed, lift the read lock from the primary
+    (`db01`) by typing the following, or by exiting the open session:
 
 
-        # mysql -u root -p
         mysql> UNLOCK TABLES;
 
 7.  Copy the database dump file to the replica server so that it can

--- a/content/cloud-servers/set-up-mysql-primary-replica-replication.md
+++ b/content/cloud-servers/set-up-mysql-primary-replica-replication.md
@@ -5,8 +5,8 @@ title: Set up MySQL primary-replica replication
 type: article
 created_date: '2011-06-02'
 created_by: Rackspace Support
-last_modified_date: '2019-09-06'
-last_modified_by: William Loy
+last_modified_date: '2020-09-01'
+last_modified_by: Rose Morales
 product: Cloud Servers
 product_url: cloud-servers
 ---
@@ -48,16 +48,16 @@ section.
 Create two Linux&reg; cloud servers, using the Centos 6 base image. Use the
 following steps to create each server separately.
 
-1.  Log in to the [Cloud Control Panel](https://login.rackspace.com).
-2.  In the top navigation bar, click **Select a Product** then **Rackspace Cloud**.
-3.  Select **Servers** then **Cloud Servers**.
-4.  Click **Create Server**.
-5.  Name the servers so that you can easily identify them during
+1. Log in to the [Cloud Control Panel](https://login.rackspace.com).
+2. In the top navigation bar, click **Select a Product** then **Rackspace Cloud**.
+3. Select **Servers** then **Cloud Servers**.
+4. Click **Create Server**.
+5. Name the servers so that you can easily identify them during
     the setup.
-6.  Select the Centos 6 base image.
-7.  Select the RAM configuration (flavor) appropriate for your
+6. Select the Centos 6 base image.
+7. Select the RAM configuration (flavor) appropriate for your
     database requirements.
-8.  Click **Create Server**.
+8. Click **Create Server**.
 
 The commands outlined in the following sections need to be executed by a
 privileged root or sudo group user. Any strings or values specified in
@@ -68,34 +68,28 @@ brackets should be replaced with data specific to your setup.
 You must install the *mysql-server* package on both CentOS cloud
 servers.
 
-
-1.  Before installing MySQL, confirm that the package database is
+1. Before installing MySQL, confirm that the package database is
     up-to-date by running the following command:
-
 
         #yum update
 
-2.  Install MySQL and enable it to run at boot automatically:
-
+2. Install MySQL and enable it to run at boot automatically:
 
          #yum install mysql-server
-        #chkconfig mysqld on
+         #chkconfig mysqld on
 
-3.  Start the `mysqld` service:
-
+3. Start the `mysqld` service:
 
         #service mysqld start
 
-4.  After the `mysqld` service has been started, set your MySQL server
+4. After the `mysqld` service has been started, set your MySQL server
     root password by using following commands:
-
 
         /usr/bin/mysqladmin -u root password 'new-password'
         /usr/bin/mysqladmin -u root -h web01 password 'new-password'
 
     **Note**: Alternatively, you can run the secure installation script
     packaged with the MySQL installation:
-
 
         # /usr/bin/mysql_secure_installation
         Enter current password for root (enter for none):
@@ -110,14 +104,13 @@ servers.
         ...
         Reload privilege tables now? [Y/n] Y
 
-5.  To permit connections on port 3306 (the `mysqld` default port), add a
+5. To permit connections on port 3306 (the `mysqld` default port), add a
     TCP port 3306 rule with an insert at the last line number in the
     `RH-Firewall-1-INPUT` chain (in this case, line 10):
 
-
         # iptables -I RH-Firewall-1-INPUT 10 -p tcp --dport 3306 -j ACCEPT
 
-6.  Save the firewall configuration:
+6. Save the firewall configuration:
 
         # service iptables save
 
@@ -129,7 +122,7 @@ enable replication.
 A MySQL user is required on the primary server (`db01`) to be used for
 replication.
 
-1.  Run the following commands to set up the MySQL user, updating the
+1. Run the following commands to set up the MySQL user, updating the
     entries in brackets with strings or values that you plan to use
     with your setup:
 
@@ -141,30 +134,27 @@ replication.
         mysql> flush privileges;
         mysql> quit
 
-2.  Edit the **/etc/my.cnf** file, and add the following entries:
-
+2. Edit the **/etc/my.cnf** file, and add the following entries:
 
         bind-address = 0.0.0.0
         server-id = 1
         log-bin = mysql-bin
         binlog-ignore-db = "mysql"
 
-3.  After you have finished updating the **/etc/my.cnf** file, restart
+3. After you have finished updating the **/etc/my.cnf** file, restart
     the `mysqld` service.
 
-
-        #service mysqld restart
+        # service mysqld restart
 
     Before starting replication, the data on the primary
     and replica servers must be the same. To accomplish this duplication, dump
     the data from the primary (`db01`) server and add it to the
     replica (`db02`) server.
 
-4.  Use the following command to ensure that nothing can write to the
+4. Use the following command to ensure that nothing can write to the
     primary database during a database dump. Also note the filename and
     position of the binary log because you need these values to
     complete the replication configuration on db02:
-
 
         # mysql -u root -p
         mysql> FLUSH TABLES WITH READ LOCK;
@@ -179,28 +169,25 @@ replication.
 
       **Note 1:** Record the filename and position of the binary log because you need these values to
       complete the replication configuration on `db02`.
-      
+
       **Note 2:** Keep this session open, closing it releases the lock!
-      
-5.  Perform a database dump by using `mysqldump` as follows:
+
+5. Perform a database dump by using `mysqldump` as follows:
 
         # mysqldump -u root -p --databases [database-1] [database-2] ...  > /root/db_dump.sql
 
-6.  After the database dump has completed, lift the read lock from the primary
+6. After the database dump has completed, lift the read lock from the primary
     (`db01`) by typing the following, or by exiting the open session:
-
 
         mysql> UNLOCK TABLES;
 
-7.  Copy the database dump file to the replica server so that it can
+7. Copy the database dump file to the replica server so that it can
     be restored by using the following command:
-
 
         scp /root/db_dump.sql [private-IP-of-db02]:/root/
 
-8.  On `db02`, edit the **/etc/my.cnf** file and add the following
+8. On `db02`, edit the **/etc/my.cnf** file and add the following
     entries:
-
 
         bind-address = 0.0.0.0
         server-id = 2
@@ -209,9 +196,8 @@ replication.
         master-password = [replication-password]
         master-connect-retry = 60
 
-9.  Import the **db\_dump.sql** file copied earlier and restart the
+9. Import the **db\_dump.sql** file copied earlier and restart the
     MySQL service.
-
 
         # mysql -u root -p < /root/db_dump.sql
         # service mysqld restart
@@ -240,7 +226,6 @@ To test the replication setup, create a new database and associated
 table on `db01` and insert data to confirm that the changes are mirrored
 on `db02`. In the following example, the new database is named
 **testing**, and the new table is named **users**:
-
 
     # mysql -u root -p
     mysql> create database testing;


### PR DESCRIPTION
The read (write) lock is only held as long as the session remains open.  The writeup here suggests starting a new mysql session to release the lock.  That is misleading.

