### PR TITLE
Fix broken link

### DIFF
--- a/content/cloud-servers/list-cloud-monitoring-zones-with-pitchfork.md
+++ b/content/cloud-servers/list-cloud-monitoring-zones-with-pitchfork.md
@@ -18,6 +18,7 @@ Cloud API tool, Pitchfork.
 
 Log in to Pitchfork at [https://pitchfork.rax.io/](https://pitchfork.rax.io/).
 
+
 To learn how to log in to and use Pitchfork, refer to (https://support.rackspace.com/how-to/pitchfork-the-rackspace-cloud-api-web-application/)[Pitchfork&mdash;the Rackspace Cloud API web application].
 
 ### List the Cloud Monitoring zones with Pitchfork


### PR DESCRIPTION
On line 22, there is a broken link on the page. It looks to be correct on the format, but it's not creating the link on the page. 

I had to add an extra line to submit the change request as I'm not sure what needs to change on line 22 to display the correct link.

